### PR TITLE
feat: 주종 관련 API 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
+++ b/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
@@ -1,0 +1,23 @@
+package com.challang.backend.liquor.code;
+
+import com.challang.backend.util.response.ResponseStatus;
+import lombok.*;
+import org.springframework.http.*;
+
+
+@Getter
+@AllArgsConstructor
+public enum LiquorCode implements ResponseStatus {
+
+    // 주종 관련
+    LIQUOR_TYPE_DELETE_SUCCESS(HttpStatus.OK, true, 200, "주종이 성공적으로 삭제되었습니다."),
+
+    LIQUOR_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 주종을 찾을 수 없습니다."),
+    LIQUOR_TYPE_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 주종입니다.");
+
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+}

--- a/backend/src/main/java/com/challang/backend/liquor/controller/LiquorTypeController.java
+++ b/backend/src/main/java/com/challang/backend/liquor/controller/LiquorTypeController.java
@@ -1,0 +1,86 @@
+package com.challang.backend.liquor.controller;
+
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.dto.request.LiquorTypeRequest;
+import com.challang.backend.liquor.dto.response.LiquorTypeResponse;
+import com.challang.backend.liquor.service.LiquorTypeService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Liquor Type", description = "주종 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/liquor-types")
+public class LiquorTypeController {
+
+    private final LiquorTypeService liquorTypeService;
+
+    // TODO: 관리자만 접근 가능하게
+    @Operation(summary = "[관리자] 주종 생성", description = "새로운 주종을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주종 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 주종 이름")
+    })
+    @PostMapping
+    public ResponseEntity<BaseResponse<LiquorTypeResponse>> create(@RequestBody @Valid LiquorTypeRequest request) {
+        LiquorTypeResponse response = liquorTypeService.create(request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "주종 단건 조회", description = "ID로 특정 주종을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주종 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 주종이 존재하지 않음")
+    })
+    @GetMapping("/{typeId}")
+    public ResponseEntity<BaseResponse<LiquorTypeResponse>> findById(@PathVariable Long typeId) {
+        LiquorTypeResponse response = liquorTypeService.findById(typeId);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "주종 전체 조회", description = "등록된 모든 주종을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주종 전체 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<LiquorTypeResponse>>> findAll() {
+        List<LiquorTypeResponse> response = liquorTypeService.findAll();
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "[관리자] 주종 수정", description = "특정 주종의 이름을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주종 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 주종이 존재하지 않음"),
+            @ApiResponse(responseCode = "409", description = "중복된 주종 이름 존재")
+    })
+    @PutMapping("/{typeId}")
+    public ResponseEntity<BaseResponse<LiquorTypeResponse>> update(
+            @PathVariable Long typeId,
+            @RequestBody @Valid LiquorTypeRequest request
+    ) {
+        LiquorTypeResponse response = liquorTypeService.update(typeId, request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "[관리자] 주종 삭제", description = "특정 주종을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주종 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 주종이 존재하지 않음")
+    })
+    @DeleteMapping("/{typeId}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long typeId) {
+        liquorTypeService.delete(typeId);
+        return ResponseEntity.ok(new BaseResponse<>(LiquorCode.LIQUOR_TYPE_DELETE_SUCCESS));
+    }
+}
+

--- a/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorTypeRequest.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorTypeRequest.java
@@ -1,0 +1,9 @@
+package com.challang.backend.liquor.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LiquorTypeRequest(
+        @NotBlank(message = "주종 이름을 필수 입력값입니다.")
+        String name
+) {
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorTypeResponse.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorTypeResponse.java
@@ -1,0 +1,13 @@
+package com.challang.backend.liquor.dto.response;
+
+import com.challang.backend.liquor.entity.LiquorType;
+
+public record LiquorTypeResponse(
+        Long id,
+        String name
+) {
+    public static LiquorTypeResponse fromEntity(LiquorType type) {
+        return new LiquorTypeResponse(type.getId(), type.getName());
+    }
+
+}

--- a/backend/src/main/java/com/challang/backend/liquor/entity/LiquorType.java
+++ b/backend/src/main/java/com/challang/backend/liquor/entity/LiquorType.java
@@ -1,5 +1,6 @@
 package com.challang.backend.liquor.entity;
 
+import com.challang.backend.liquor.dto.request.LiquorTypeRequest;
 import com.challang.backend.util.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,4 +18,11 @@ public class LiquorType extends BaseEntity {
     @Column(name = "name", nullable = false, unique = true)
     private String name;  // ex. 소주, 와인
 
+    public LiquorType(String name) {
+        this.name = name;
+    }
+
+    public void update(LiquorTypeRequest request) {
+        this.name = request.name();
+    }
 }

--- a/backend/src/main/java/com/challang/backend/liquor/repository/LiquorTypeRepository.java
+++ b/backend/src/main/java/com/challang/backend/liquor/repository/LiquorTypeRepository.java
@@ -1,0 +1,11 @@
+package com.challang.backend.liquor.repository;
+
+import com.challang.backend.liquor.entity.LiquorType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LiquorTypeRepository extends JpaRepository<LiquorType, Long> {
+
+    boolean existsByName(String name);
+}

--- a/backend/src/main/java/com/challang/backend/liquor/service/LiquorTypeService.java
+++ b/backend/src/main/java/com/challang/backend/liquor/service/LiquorTypeService.java
@@ -1,0 +1,69 @@
+package com.challang.backend.liquor.service;
+
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.liquor.dto.request.LiquorTypeRequest;
+import com.challang.backend.liquor.dto.response.LiquorTypeResponse;
+import com.challang.backend.liquor.entity.LiquorType;
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.repository.LiquorTypeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LiquorTypeService {
+
+    private final LiquorTypeRepository liquorTypeRepository;
+
+    // 주종 추가
+    public LiquorTypeResponse create(LiquorTypeRequest request) {
+        if (liquorTypeRepository.existsByName(request.name())) {
+            throw new BaseException(LiquorCode.LIQUOR_TYPE_ALREADY_EXISTS);
+        }
+
+        LiquorType type = new LiquorType(request.name());
+        LiquorType saved = liquorTypeRepository.save(type);
+        return LiquorTypeResponse.fromEntity(saved);
+    }
+
+    // 주종 조회
+    @Transactional(readOnly = true)
+    public LiquorTypeResponse findById(Long id) {
+        return LiquorTypeResponse.fromEntity(getLiquorTypeById(id));
+    }
+
+    // 주종 전체 조회
+    @Transactional(readOnly = true)
+    public List<LiquorTypeResponse> findAll() {
+        return liquorTypeRepository.findAll().stream()
+                .map(LiquorTypeResponse::fromEntity)
+                .toList();
+    }
+
+    // 주종 수정
+    public LiquorTypeResponse update(Long id, LiquorTypeRequest request) {
+        LiquorType type = getLiquorTypeById(id);
+
+        if (liquorTypeRepository.existsByName(request.name()) &&
+                !type.getName().equals(request.name())) {
+            throw new BaseException(LiquorCode.LIQUOR_TYPE_ALREADY_EXISTS);
+        }
+
+        type.update(request);
+        return LiquorTypeResponse.fromEntity(type);
+    }
+
+    // 주종 삭제
+    public void delete(Long id) {
+        LiquorType type = getLiquorTypeById(id);
+        liquorTypeRepository.delete(type);
+    }
+
+    private LiquorType getLiquorTypeById(Long id) {
+        return liquorTypeRepository.findById(id)
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_TYPE_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
### 주요 내용
- 주종 생성, 조회(단건/전체), 수정, 삭제 API 구현
- 경로: `/api/liquor-types`
- 중복 이름 체크 및 예외 처리 추가
- Swagger 문서화 적용 (`@Operation`, `@ApiResponses`)


> 관리자 권한 제어는 추후 적용 예정

closes #19 