### PR TITLE
feat: 도수 등급 관련 API 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
+++ b/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
@@ -13,7 +13,13 @@ public enum LiquorCode implements ResponseStatus {
     LIQUOR_TYPE_DELETE_SUCCESS(HttpStatus.OK, true, 200, "주종이 성공적으로 삭제되었습니다."),
 
     LIQUOR_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 주종을 찾을 수 없습니다."),
-    LIQUOR_TYPE_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 주종입니다.");
+    LIQUOR_TYPE_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 주종입니다."),
+
+    // 도수 관련
+    LIQUOR_LEVEL_DELETE_SUCCESS(HttpStatus.OK, true, 200, "도수 등급이 성공적으로 삭제되었습니다."),
+
+    LIQUOR_LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 도수 등급을 찾을 수 없습니다."),
+    LIQUOR_LEVEL_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 도수 등급입니다.");
 
 
     private final HttpStatusCode httpStatusCode;

--- a/backend/src/main/java/com/challang/backend/liquor/controller/LiquorLevelController.java
+++ b/backend/src/main/java/com/challang/backend/liquor/controller/LiquorLevelController.java
@@ -1,0 +1,85 @@
+package com.challang.backend.liquor.controller;
+
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.dto.request.LiquorLevelRequest;
+import com.challang.backend.liquor.dto.response.LiquorLevelResponse;
+import com.challang.backend.liquor.service.LiquorLevelService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Liquor Level", description = "도수 등급 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/liquor-levels")
+public class LiquorLevelController {
+
+    private final LiquorLevelService liquorLevelService;
+
+    // TODO: 관리자만 접근 가능하게
+    @Operation(summary = "[관리자] 도수 등급 생성", description = "새로운 도수 등급을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "도수 등급 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 도수 등급 이름")
+    })
+    @PostMapping
+    public ResponseEntity<BaseResponse<LiquorLevelResponse>> create(@RequestBody @Valid LiquorLevelRequest request) {
+        LiquorLevelResponse response = liquorLevelService.create(request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "도수 등급 단건 조회", description = "ID로 특정 도수 등급을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "도수 등급 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 도수 등급이 존재하지 않음")
+    })
+    @GetMapping("/{levelId}")
+    public ResponseEntity<BaseResponse<LiquorLevelResponse>> findById(@PathVariable Long levelId) {
+        LiquorLevelResponse response = liquorLevelService.findById(levelId);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "도수 등급 전체 조회", description = "등록된 모든 도수 등급을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "도수 등급 전체 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<LiquorLevelResponse>>> findAll() {
+        List<LiquorLevelResponse> response = liquorLevelService.findAll();
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "[관리자] 도수 등급 수정", description = "특정 도수 등급의 이름을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "도수 등급 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 도수 등급이 존재하지 않음"),
+            @ApiResponse(responseCode = "409", description = "중복된 도수 등급 이름 존재")
+    })
+    @PutMapping("/{levelId}")
+    public ResponseEntity<BaseResponse<LiquorLevelResponse>> update(
+            @PathVariable Long levelId,
+            @RequestBody @Valid LiquorLevelRequest request
+    ) {
+        LiquorLevelResponse response = liquorLevelService.update(levelId, request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "[관리자] 도수 등급 삭제", description = "특정 도수 등급을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "도수 등급 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 도수 등급이 존재하지 않음")
+    })
+    @DeleteMapping("/{levelId}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long levelId) {
+        liquorLevelService.delete(levelId);
+        return ResponseEntity.ok(new BaseResponse<>(LiquorCode.LIQUOR_LEVEL_DELETE_SUCCESS));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorLevelRequest.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorLevelRequest.java
@@ -1,0 +1,9 @@
+package com.challang.backend.liquor.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LiquorLevelRequest(
+        @NotBlank(message = "도수 등급 이름은 필수 입력값입니다.")
+        String name
+) {
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorLevelResponse.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorLevelResponse.java
@@ -1,0 +1,13 @@
+package com.challang.backend.liquor.dto.response;
+
+
+import com.challang.backend.liquor.entity.LiquorLevel;
+
+public record LiquorLevelResponse(
+        Long id,
+        String name
+) {
+    public static LiquorLevelResponse fromEntity(LiquorLevel level) {
+        return new LiquorLevelResponse(level.getId(), level.getName());
+    }
+}

--- a/backend/src/main/java/com/challang/backend/liquor/entity/LiquorLevel.java
+++ b/backend/src/main/java/com/challang/backend/liquor/entity/LiquorLevel.java
@@ -1,5 +1,6 @@
 package com.challang.backend.liquor.entity;
 
+import com.challang.backend.liquor.dto.request.LiquorLevelRequest;
 import com.challang.backend.util.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -18,4 +19,11 @@ public class LiquorLevel extends BaseEntity {
     @Column(name = "name", nullable = false, unique = true)
     private String name;  // ex. 저도수, 중도수, 고도수
 
+    public LiquorLevel(String name) {
+        this.name = name;
+    }
+
+    public void update(LiquorLevelRequest request) {
+        this.name = request.name();
+    }
 }

--- a/backend/src/main/java/com/challang/backend/liquor/repository/LiquorLevelRepository.java
+++ b/backend/src/main/java/com/challang/backend/liquor/repository/LiquorLevelRepository.java
@@ -1,0 +1,12 @@
+package com.challang.backend.liquor.repository;
+
+import com.challang.backend.liquor.entity.LiquorLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LiquorLevelRepository extends JpaRepository<LiquorLevel, Long> {
+
+    boolean existsByName(String name);
+
+}

--- a/backend/src/main/java/com/challang/backend/liquor/service/LiquorLevelService.java
+++ b/backend/src/main/java/com/challang/backend/liquor/service/LiquorLevelService.java
@@ -1,0 +1,72 @@
+package com.challang.backend.liquor.service;
+
+
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.dto.request.LiquorLevelRequest;
+import com.challang.backend.liquor.dto.response.LiquorLevelResponse;
+import com.challang.backend.liquor.entity.LiquorLevel;
+import com.challang.backend.liquor.repository.LiquorLevelRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LiquorLevelService {
+
+    private final LiquorLevelRepository liquorLevelRepository;
+
+    // 생성
+    public LiquorLevelResponse create(LiquorLevelRequest request) {
+        if (liquorLevelRepository.existsByName(request.name())) {
+            throw new BaseException(LiquorCode.LIQUOR_LEVEL_ALREADY_EXISTS);
+        }
+
+        LiquorLevel level = new LiquorLevel(request.name());
+        LiquorLevel saved = liquorLevelRepository.save(level);
+        return LiquorLevelResponse.fromEntity(saved);
+    }
+
+    // 단건 조회
+    @Transactional(readOnly = true)
+    public LiquorLevelResponse findById(Long id) {
+        return LiquorLevelResponse.fromEntity(getLiquorLevelById(id));
+    }
+
+    // 전체 조회
+    @Transactional(readOnly = true)
+    public List<LiquorLevelResponse> findAll() {
+        return liquorLevelRepository.findAll().stream()
+                .map(LiquorLevelResponse::fromEntity)
+                .toList();
+    }
+
+    // 주종 수정
+    public LiquorLevelResponse update(Long id, LiquorLevelRequest request) {
+        LiquorLevel level = getLiquorLevelById(id);
+
+        if (liquorLevelRepository.existsByName(request.name()) &&
+                !level.getName().equals(request.name())) {
+            throw new BaseException(LiquorCode.LIQUOR_LEVEL_ALREADY_EXISTS);
+        }
+
+        level.update(request);
+        return LiquorLevelResponse.fromEntity(level);
+    }
+
+    // 주종 삭제
+    public void delete(Long id) {
+        LiquorLevel level = getLiquorLevelById(id);
+        liquorLevelRepository.delete(level);
+    }
+
+    private LiquorLevel getLiquorLevelById(Long id) {
+        return liquorLevelRepository.findById(id)
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_LEVEL_NOT_FOUND));
+    }
+
+
+}


### PR DESCRIPTION
### 주요 내용
- 도수 등급 생성, 조회(단건/전체), 수정, 삭제 API 구현
- 경로: `/api/liquor-levels`
- 중복 이름 체크 및 예외 처리 추가


> 관리자 권한 제어는 추후 적용 예정

closes #20 