### PR TITLE
feat: 스타일 태그 관련 API 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/tag/code/TagCode.java
+++ b/backend/src/main/java/com/challang/backend/tag/code/TagCode.java
@@ -1,0 +1,23 @@
+package com.challang.backend.tag.code;
+
+import com.challang.backend.util.response.ResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum TagCode implements ResponseStatus {
+
+    // 태그 관련
+    TAG_DELETE_SUCCESS(HttpStatus.OK, true, 200, "태그가 성공적으로 삭제되었습니다."),
+
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 태그를 찾을 수 없습니다."),
+    TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 태그입니다.");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+}

--- a/backend/src/main/java/com/challang/backend/tag/controller/TagController.java
+++ b/backend/src/main/java/com/challang/backend/tag/controller/TagController.java
@@ -1,0 +1,85 @@
+package com.challang.backend.tag.controller;
+
+import com.challang.backend.tag.code.TagCode;
+import com.challang.backend.tag.dto.request.TagRequest;
+import com.challang.backend.tag.dto.response.TagResponse;
+import com.challang.backend.tag.service.TagService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Tag", description = "태그 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tags")
+public class TagController {
+
+    private final TagService tagService;
+
+    // TODO: 관리자만 접근 가능하게
+    @Operation(summary = "[관리자] 태그 생성", description = "새로운 태그를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "태그 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 태그 이름")
+    })
+    @PostMapping
+    public ResponseEntity<BaseResponse<TagResponse>> create(@RequestBody @Valid TagRequest request) {
+        TagResponse response = tagService.create(request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "태그 단건 조회", description = "ID로 특정 태그를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "태그 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 태그가 존재하지 않음")
+    })
+    @GetMapping("/{tagId}")
+    public ResponseEntity<BaseResponse<TagResponse>> findById(@PathVariable Long tagId) {
+        TagResponse response = tagService.findById(tagId);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "태그 전체 조회", description = "등록된 모든 태그를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "태그 전체 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<TagResponse>>> findAll() {
+        List<TagResponse> response = tagService.findAll();
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "[관리자] 태그 수정", description = "특정 태그의 이름을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "태그 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 태그가 존재하지 않음"),
+            @ApiResponse(responseCode = "409", description = "중복된 태그 이름 존재")
+    })
+    @PutMapping("/{tagId}")
+    public ResponseEntity<BaseResponse<TagResponse>> update(
+            @PathVariable Long tagId,
+            @RequestBody @Valid TagRequest request
+    ) {
+        TagResponse response = tagService.update(tagId, request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "[관리자] 태그 삭제", description = "특정 태그를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "태그 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 태그가 존재하지 않음")
+    })
+    @DeleteMapping("/{tagId}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long tagId) {
+        tagService.delete(tagId);
+        return ResponseEntity.ok(new BaseResponse<>(TagCode.TAG_DELETE_SUCCESS));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/tag/dto/request/TagRequest.java
+++ b/backend/src/main/java/com/challang/backend/tag/dto/request/TagRequest.java
@@ -1,0 +1,9 @@
+package com.challang.backend.tag.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TagRequest(
+        @NotBlank(message = "태그 이름은 필수 입력값입니다.")
+        String name
+) {
+}

--- a/backend/src/main/java/com/challang/backend/tag/dto/response/TagResponse.java
+++ b/backend/src/main/java/com/challang/backend/tag/dto/response/TagResponse.java
@@ -1,0 +1,12 @@
+package com.challang.backend.tag.dto.response;
+
+import com.challang.backend.tag.entity.Tag;
+
+public record TagResponse(
+        Long id,
+        String name
+) {
+    public static TagResponse fromEntity(Tag tag) {
+        return new TagResponse(tag.getId(), tag.getName());
+    }
+}

--- a/backend/src/main/java/com/challang/backend/tag/entity/Tag.java
+++ b/backend/src/main/java/com/challang/backend/tag/entity/Tag.java
@@ -1,5 +1,6 @@
 package com.challang.backend.tag.entity;
 
+import com.challang.backend.tag.dto.request.TagRequest;
 import com.challang.backend.util.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,4 +19,11 @@ public class Tag extends BaseEntity {
     @Column(name = "name", nullable = false, unique = true)
     private String name;  // ex. 드라이, 과일향, 오크향
 
+    public Tag(String name) {
+        this.name = name;
+    }
+
+    public void update(TagRequest request) {
+        this.name = request.name();
+    }
 }

--- a/backend/src/main/java/com/challang/backend/tag/repository/TagRepository.java
+++ b/backend/src/main/java/com/challang/backend/tag/repository/TagRepository.java
@@ -1,0 +1,12 @@
+package com.challang.backend.tag.repository;
+
+import com.challang.backend.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    boolean existsByName(String name);
+
+}

--- a/backend/src/main/java/com/challang/backend/tag/service/TagService.java
+++ b/backend/src/main/java/com/challang/backend/tag/service/TagService.java
@@ -1,0 +1,69 @@
+package com.challang.backend.tag.service;
+
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.tag.code.TagCode;
+import com.challang.backend.tag.dto.request.TagRequest;
+import com.challang.backend.tag.dto.response.TagResponse;
+import com.challang.backend.tag.entity.Tag;
+import com.challang.backend.tag.repository.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    // 태그 생성
+    public TagResponse create(TagRequest request) {
+        if (tagRepository.existsByName(request.name())) {
+            throw new BaseException(TagCode.TAG_ALREADY_EXISTS);
+        }
+
+        Tag tag = new Tag(request.name());
+        Tag saved = tagRepository.save(tag);
+        return TagResponse.fromEntity(saved);
+    }
+
+    // 태그 단건 조회
+    @Transactional(readOnly = true)
+    public TagResponse findById(Long id) {
+        return TagResponse.fromEntity(getTagById(id));
+    }
+
+    // 태그 전체 조회
+    @Transactional(readOnly = true)
+    public List<TagResponse> findAll() {
+        return tagRepository.findAll().stream()
+                .map(TagResponse::fromEntity)
+                .toList();
+    }
+
+    // 태그 수정
+    public TagResponse update(Long id, TagRequest request) {
+        Tag tag = getTagById(id);
+
+        if (tagRepository.existsByName(request.name()) &&
+                !tag.getName().equals(request.name())) {
+            throw new BaseException(TagCode.TAG_ALREADY_EXISTS);
+        }
+
+        tag.update(request);
+        return TagResponse.fromEntity(tag);
+    }
+
+    // 태그 삭제
+    public void delete(Long id) {
+        Tag tag = getTagById(id);
+        tagRepository.delete(tag);
+    }
+
+    private Tag getTagById(Long id) {
+        return tagRepository.findById(id)
+                .orElseThrow(() -> new BaseException(TagCode.TAG_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
### 주요 내용
- 스타일 태그 생성, 조회(단건/전체), 수정, 삭제 API 구현
- 경로: `/api/tags`
- 중복 이름 체크 및 예외 처리 추가


> 관리자 권한 제어는 추후 적용 예정

closes #21 