### PR TITLE
feat: Liquor 관련 API 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
+++ b/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
@@ -9,17 +9,23 @@ import org.springframework.http.*;
 @AllArgsConstructor
 public enum LiquorCode implements ResponseStatus {
 
-    // 주종 관련
-    LIQUOR_TYPE_DELETE_SUCCESS(HttpStatus.OK, true, 200, "주종이 성공적으로 삭제되었습니다."),
+    // 주류 관련
+    LIQUOR_DELETE_SUCCESS(HttpStatus.OK, true, 200, "주류 삭제에 성공했습니다."),
 
-    LIQUOR_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 주종을 찾을 수 없습니다."),
-    LIQUOR_TYPE_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 주종입니다."),
+    LIQUOR_NOT_FOUND(HttpStatus.NOT_FOUND, false,404,"주류 정보를 찾을 수 없습니다."),
+    LIQUOR_ALREADY_EXISTS(HttpStatus.CONFLICT, false,409,"이미 등록된 주류입니다."),
+
+    // 주종 관련
+    LIQUOR_TYPE_DELETE_SUCCESS(HttpStatus.OK, true,200,"주종이 성공적으로 삭제되었습니다."),
+
+    LIQUOR_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, false,404,"해당 주종을 찾을 수 없습니다."),
+    LIQUOR_TYPE_ALREADY_EXISTS(HttpStatus.CONFLICT, false,409,"이미 존재하는 주종입니다."),
 
     // 도수 관련
-    LIQUOR_LEVEL_DELETE_SUCCESS(HttpStatus.OK, true, 200, "도수 등급이 성공적으로 삭제되었습니다."),
+    LIQUOR_LEVEL_DELETE_SUCCESS(HttpStatus.OK, true,200,"도수 등급이 성공적으로 삭제되었습니다."),
 
-    LIQUOR_LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 도수 등급을 찾을 수 없습니다."),
-    LIQUOR_LEVEL_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 도수 등급입니다.");
+    LIQUOR_LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, false,404,"해당 도수 등급을 찾을 수 없습니다."),
+    LIQUOR_LEVEL_ALREADY_EXISTS(HttpStatus.CONFLICT, false,409,"이미 존재하는 도수 등급입니다.");
 
 
     private final HttpStatusCode httpStatusCode;

--- a/backend/src/main/java/com/challang/backend/liquor/controller/LiquorController.java
+++ b/backend/src/main/java/com/challang/backend/liquor/controller/LiquorController.java
@@ -1,0 +1,91 @@
+package com.challang.backend.liquor.controller;
+
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.dto.request.*;
+import com.challang.backend.liquor.dto.response.*;
+import com.challang.backend.liquor.service.LiquorService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Liquor", description = "주류 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/liquors")
+public class LiquorController {
+
+    private final LiquorService liquorService;
+
+    // TODO: 관리자만 접근 가능하게
+    @Operation(summary = "[관리자] 주류 등록", description = "새로운 주류를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주류 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 주류 이름")
+    })
+    @PostMapping
+    public ResponseEntity<BaseResponse<LiquorResponse>> create(@RequestBody @Valid LiquorCreateRequest request) {
+        LiquorResponse response = liquorService.create(request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "주류 단건 조회", description = "ID로 특정 주류를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주류 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 주류가 존재하지 않음")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<LiquorResponse>> findById(@PathVariable Long id) {
+        LiquorResponse response = liquorService.findById(id);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "주류 전체 조회", description = "이름 기준 커서 방식으로 주류 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주류 전체 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse<LiquorListResponse>> findAll(
+            @RequestParam(required = false) String cursorName,
+            @RequestParam(defaultValue = "10") Integer pageSize
+    ) {
+        LiquorListResponse response = liquorService.findAll(cursorName, pageSize);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    // TODO: 관리자만 접근 가능하게
+    @Operation(summary = "[관리자] 주류 수정", description = "주류 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주류 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 유효성 검증 실패"),
+            @ApiResponse(responseCode = "404", description = "해당 주류가 존재하지 않음"),
+            @ApiResponse(responseCode = "409", description = "중복된 주류 이름 존재")
+    })
+    @PatchMapping("/{id}")
+    public ResponseEntity<BaseResponse<LiquorResponse>> update(
+            @PathVariable Long id,
+            @RequestBody @Valid LiquorUpdateRequest request
+    ) {
+        LiquorResponse response = liquorService.update(id, request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+
+    // TODO: 관리자만 접근 가능하게
+    @Operation(summary = "[관리자] 주류 삭제", description = "특정 주류를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주류 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 주류가 존재하지 않음")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id) {
+        liquorService.delete(id);
+        return ResponseEntity.ok(new BaseResponse<>(LiquorCode.LIQUOR_DELETE_SUCCESS));
+    }
+
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorCreateRequest.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorCreateRequest.java
@@ -1,0 +1,35 @@
+package com.challang.backend.liquor.dto.request;
+
+import jakarta.validation.constraints.*;
+
+// TODO: Tag 추가 예정
+public record LiquorCreateRequest(
+
+        @NotBlank(message = "술 이름은 필수입니다.")
+        String name,
+
+        // TODO: 나중에 필수로 추가하기
+        String imageUrl,
+
+        @NotBlank(message = "베이스는 필수입니다. 어떤 원료로 만들어졌는지 입력해주세요. (예: 쌀, 보리 등)")
+        String base,
+
+        @NotBlank(message = "유래는 필수입니다. 간략한 술의 역사나 기원을 입력해주세요.")
+        String origin,
+
+        @NotBlank(message = "색상은 필수입니다.")
+        String color,
+
+        @NotNull(message = "최소 도수는 필수입니다.")
+        Double minAbv,
+
+        @NotNull(message = "최대 도수는 필수입니다.")
+        Double maxAbv,
+
+        @NotNull(message = "도수 등급 ID는 필수입니다.")
+        Long levelId,
+
+        @NotNull(message = "주종 ID는 필수입니다.")
+        Long typeId
+) {
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorUpdateRequest.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.challang.backend.liquor.dto.request;
+
+public record LiquorUpdateRequest(
+
+        String name,
+        String imageUrl,
+        String base,
+        String origin,
+        String color,
+        Double minAbv,
+        Double maxAbv,
+        Long levelId,
+        Long typeId
+) {
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorListResponse.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorListResponse.java
@@ -1,0 +1,10 @@
+package com.challang.backend.liquor.dto.response;
+
+import java.util.List;
+
+public record LiquorListResponse(
+        List<LiquorResponse> items,
+        String nextCursorName,
+        boolean hasNext) {
+}
+

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
@@ -1,0 +1,37 @@
+package com.challang.backend.liquor.dto.response;
+
+import com.challang.backend.liquor.entity.Liquor;
+
+// TODO: Tag 추가 예정
+public record LiquorResponse(
+        Long id,
+        String name,
+        String imageUrl,
+        String base,
+        String origin,
+        String color,
+        Double minAbv,
+        Double maxAbv,
+        Long levelId,
+        String levelName,
+        Long typeId,
+        String typeName
+) {
+    public static LiquorResponse fromEntity(Liquor liquor) {
+        return new LiquorResponse(
+                liquor.getId(),
+                liquor.getName(),
+                liquor.getImageUrl(),
+                liquor.getBase(),
+                liquor.getOrigin(),
+                liquor.getColor(),
+                liquor.getMinAbv(),
+                liquor.getMaxAbv(),
+                liquor.getLevel().getId(),
+                liquor.getLevel().getName(),
+                liquor.getType().getId(),
+                liquor.getType().getName()
+        );
+    }
+
+}

--- a/backend/src/main/java/com/challang/backend/liquor/entity/Liquor.java
+++ b/backend/src/main/java/com/challang/backend/liquor/entity/Liquor.java
@@ -1,5 +1,6 @@
 package com.challang.backend.liquor.entity;
 
+import com.challang.backend.liquor.dto.request.LiquorUpdateRequest;
 import com.challang.backend.tag.entity.LiquorTag;
 import com.challang.backend.util.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -27,7 +28,8 @@ public class Liquor extends BaseEntity {
     @Column(name = "name", nullable = false, unique = true)
     private String name;
 
-    @Column(name = "image_url", nullable = false)
+    // TODO: 나중에 이미지 추가
+    @Column(name = "image_url")
     private String imageUrl;
 
     @Column(name = "base", nullable = false)
@@ -40,11 +42,56 @@ public class Liquor extends BaseEntity {
     private String color;
 
     @Column(name = "min_abv", nullable = false)
-    private Float minAbv;
+    private Double minAbv;
 
-    @Column(name = "max_abv",  nullable = false)
-    private Float maxAbv;
+    @Column(name = "max_abv", nullable = false)
+    private Double maxAbv;
 
     @OneToMany(mappedBy = "liquor")
     private final List<LiquorTag> liquorTags = new ArrayList<>();
+
+
+    @Builder
+    public Liquor(LiquorLevel level, LiquorType type, String name, String imageUrl, String base, String origin,
+                  String color, Double minAbv, Double maxAbv) {
+        this.level = level;
+        this.type = type;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.base = base;
+        this.origin = origin;
+        this.color = color;
+        this.minAbv = minAbv;
+        this.maxAbv = maxAbv;
+    }
+
+    public void update(LiquorUpdateRequest request, LiquorLevel level, LiquorType type) {
+        if (request.name() != null) {
+            this.name = request.name();
+        }
+        if (request.base() != null) {
+            this.base = request.base();
+        }
+        if (request.origin() != null) {
+            this.origin = request.origin();
+        }
+        if (request.color() != null) {
+            this.color = request.color();
+        }
+        if (request.minAbv() != null) {
+            this.minAbv = request.minAbv();
+        }
+        if (request.maxAbv() != null) {
+            this.maxAbv = request.maxAbv();
+        }
+        if (request.imageUrl() != null) {
+            this.imageUrl = request.imageUrl();
+        }
+        if (level != null) {
+            this.level = level;
+        }
+        if (type != null) {
+            this.type = type;
+        }
+    }
 }

--- a/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
+++ b/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
@@ -1,0 +1,17 @@
+package com.challang.backend.liquor.repository;
+
+import com.challang.backend.liquor.entity.Liquor;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LiquorRepository extends JpaRepository<Liquor, Long> {
+
+    boolean existsByName(String name);
+    boolean existsByNameAndIdNot(String name, Long id);
+
+    List<Liquor> findAllByOrderByNameDesc(Pageable pageable);
+    List<Liquor> findByNameLessThanOrderByNameDesc(String name, Pageable pageable);
+}

--- a/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
+++ b/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
@@ -1,0 +1,133 @@
+package com.challang.backend.liquor.service;
+
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.dto.request.LiquorCreateRequest;
+import com.challang.backend.liquor.dto.request.LiquorUpdateRequest;
+import com.challang.backend.liquor.dto.response.LiquorListResponse;
+import com.challang.backend.liquor.dto.response.LiquorResponse;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.liquor.entity.LiquorLevel;
+import com.challang.backend.liquor.entity.LiquorType;
+import com.challang.backend.liquor.repository.LiquorLevelRepository;
+import com.challang.backend.liquor.repository.LiquorRepository;
+import com.challang.backend.liquor.repository.LiquorTypeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LiquorService {
+
+    private final LiquorRepository liquorRepository;
+    private final LiquorLevelRepository levelRepository;
+    private final LiquorTypeRepository typeRepository;
+
+    // TODO: 태그 추가해야함
+
+    // 주류 추가
+    public LiquorResponse create(LiquorCreateRequest request) {
+        if (liquorRepository.existsByName(request.name())) {
+            throw new BaseException(LiquorCode.LIQUOR_ALREADY_EXISTS);
+        }
+
+        LiquorLevel level = levelRepository.findById(request.levelId())
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_LEVEL_NOT_FOUND));
+        LiquorType type = typeRepository.findById(request.typeId())
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_TYPE_NOT_FOUND));
+
+        Liquor liquor = Liquor.builder()
+                .name(request.name())
+                .base(request.base())
+                .origin(request.origin())
+                .color(request.color())
+                .minAbv(request.minAbv())
+                .maxAbv(request.maxAbv())
+                .level(level)
+                .type(type)
+                .build();
+
+        Liquor saved = liquorRepository.save(liquor);
+        return LiquorResponse.fromEntity(saved);
+    }
+
+    // 주류 단건 조회
+    @Transactional(readOnly = true)
+    public LiquorResponse findById(Long id) {
+        return LiquorResponse.fromEntity(getLiquorById(id));
+    }
+
+    // 주류 전체 조회
+    @Transactional(readOnly = true)
+    public LiquorListResponse findAll(String cursorName, Integer pageSize) {
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
+
+        List<Liquor> liquors = cursorName == null ? liquorRepository.findAllByOrderByNameDesc(pageable)
+                : liquorRepository.findByNameLessThanOrderByNameDesc(cursorName, pageable);
+
+        boolean hasNext = liquors.size() > pageSize;
+        if (hasNext) {
+            liquors = liquors.subList(0, pageSize);
+        }
+
+        String nextCursor = hasNext ? liquors.get(pageSize - 1).getName() : null;
+
+        return new LiquorListResponse(
+                liquors.stream().map(LiquorResponse::fromEntity).toList(),
+                nextCursor,
+                hasNext
+        );
+    }
+
+
+    // 주류 수정
+    public LiquorResponse update(Long id, LiquorUpdateRequest request) {
+        Liquor liquor = getLiquorById(id);
+
+        if (request.name() != null && liquorRepository.existsByNameAndIdNot(request.name(), id)) {
+            throw new BaseException(LiquorCode.LIQUOR_ALREADY_EXISTS);
+        }
+
+        LiquorLevel level = findLevelOrNull(request.levelId());
+        LiquorType type = findTypeOrNull(request.typeId());
+
+        liquor.update(request, level, type);
+        return LiquorResponse.fromEntity(liquor);
+    }
+
+    public void delete(Long id) {
+        Liquor liquor = getLiquorById(id);
+        liquorRepository.delete(liquor);
+    }
+
+
+
+    private Liquor getLiquorById(Long id) {
+        return liquorRepository.findById(id)
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_NOT_FOUND));
+    }
+
+    private LiquorLevel findLevelOrNull(Long levelId) {
+        if (levelId == null) {
+            return null;
+        }
+        return levelRepository.findById(levelId)
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_LEVEL_NOT_FOUND));
+    }
+
+    private LiquorType findTypeOrNull(Long typeId) {
+        if (typeId == null) {
+            return null;
+        }
+        return typeRepository.findById(typeId)
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_TYPE_NOT_FOUND));
+    }
+
+
+}


### PR DESCRIPTION
## 주요 내용
- 주류 생성, 조회(단건/전체), 수정, 삭제 API 구현
- 경로: `/api/liqours`
- 중복 이름 체크 및 예외 처리 추가

## TODO
- 술-스타일 태그 매핑 테이블
- 이미지 추가


> 관리자 권한 제어는 추후 적용 예정

closes #18 