### PR TITLE
feat: 로그인 사용자 정보 주입용 @CurrentUser 어노테이션 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/auth/annotation/CurrentUser.java
+++ b/backend/src/main/java/com/challang/backend/auth/annotation/CurrentUser.java
@@ -1,0 +1,10 @@
+package com.challang.backend.auth.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface CurrentUser {
+}

--- a/backend/src/main/java/com/challang/backend/auth/exception/AuthErrorCode.java
+++ b/backend/src/main/java/com/challang/backend/auth/exception/AuthErrorCode.java
@@ -20,7 +20,8 @@ public enum AuthErrorCode implements ResponseStatus {
     EMAIL_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, false, 400, "이메일 인증에 실패했습니다."),
 
 
-    LOGOUT_FAILED(HttpStatus.BAD_REQUEST, false, 400, "로그아웃에 실패했습니다.");;
+    UNAUTHORIZED_REQUEST(HttpStatus.UNAUTHORIZED, false, 401, "인증이 필요합니다. 토큰이 유효하지 않습니다."),
+    LOGOUT_FAILED(HttpStatus.BAD_REQUEST, false, 400, "로그아웃에 실패했습니다.");
 
 
     private final HttpStatusCode httpStatusCode;

--- a/backend/src/main/java/com/challang/backend/auth/resolver/CurrentUserResolver.java
+++ b/backend/src/main/java/com/challang/backend/auth/resolver/CurrentUserResolver.java
@@ -1,0 +1,52 @@
+package com.challang.backend.auth.resolver;
+
+import com.challang.backend.auth.annotation.CurrentUser;
+import com.challang.backend.auth.exception.AuthErrorCode;
+import com.challang.backend.auth.jwt.JwtUtil;
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.*;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class) && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest httpRequest = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = extractToken(httpRequest);
+
+        if (token == null) {
+            throw new BaseException(AuthErrorCode.UNAUTHORIZED_REQUEST);
+
+        }
+
+        Long id = jwtUtil.getId(token);
+        return userService.getByLoginId(id);
+    }
+
+
+    private String extractToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/challang/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/challang/backend/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.challang.backend.config;
+
+import com.challang.backend.auth.resolver.CurrentUserResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserResolver currentUserResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserResolver);
+    }
+}

--- a/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
@@ -1,10 +1,12 @@
 package com.challang.backend.review.controller;
 
+import com.challang.backend.auth.annotation.CurrentUser;
 import com.challang.backend.auth.jwt.CustomUserDetails;
 import com.challang.backend.review.dto.request.ReviewCreateRequestDto;
 import com.challang.backend.review.dto.request.ReviewUpdateRequestDto;
 import com.challang.backend.review.dto.response.ReviewResponseDto;
 import com.challang.backend.review.service.ReviewService;
+import com.challang.backend.user.entity.User;
 import com.challang.backend.util.response.BaseResponse; // BaseResponse import
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -38,9 +40,8 @@ public class ReviewController {
     public ResponseEntity<BaseResponse<ReviewResponseDto>> createReview(
             @PathVariable Long liquorId,
             @RequestBody ReviewCreateRequestDto request,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        ReviewResponseDto responseDto = reviewService.createReview(liquorId, request, userDetails.getUserId());
-        // BaseResponse 생성자를 직접 호출하여 성공 응답을 생성합니다.
+            @CurrentUser User user) {
+        ReviewResponseDto responseDto = reviewService.createReview(liquorId, request, user.getUserId());
         return ResponseEntity.ok(new BaseResponse<>(responseDto));
     }
 
@@ -51,7 +52,6 @@ public class ReviewController {
     @GetMapping("/liquors/{liquorId}/reviews")
     public ResponseEntity<BaseResponse<List<ReviewResponseDto>>> getReviews(@PathVariable Long liquorId) {
         List<ReviewResponseDto> responseDtoList = reviewService.getReviews(liquorId);
-        // BaseResponse 생성자를 직접 호출하여 성공 응답을 생성합니다.
         return ResponseEntity.ok(new BaseResponse<>(responseDtoList));
     }
 
@@ -67,9 +67,8 @@ public class ReviewController {
     public ResponseEntity<BaseResponse<ReviewResponseDto>> updateReview(
             @PathVariable Long reviewId,
             @RequestBody ReviewUpdateRequestDto request,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        ReviewResponseDto responseDto = reviewService.updateReview(reviewId, request, userDetails.getUserId());
-        // BaseResponse 생성자를 직접 호출하여 성공 응답을 생성합니다.
+            @CurrentUser User user) {
+        ReviewResponseDto responseDto = reviewService.updateReview(reviewId, request, user.getUserId());
         return ResponseEntity.ok(new BaseResponse<>(responseDto));
     }
 
@@ -82,12 +81,10 @@ public class ReviewController {
             @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
     })
     @DeleteMapping("/reviews/{reviewId}")
-    // 반환 타입의 제네릭을 <String>으로 변경하여 성공 메시지를 담습니다.
     public ResponseEntity<BaseResponse<String>> deleteReview(
             @PathVariable Long reviewId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        reviewService.deleteReview(reviewId, userDetails.getUserId());
-        // AuthController의 logout과 같이, 성공 메시지를 담은 BaseResponse를 생성합니다.
+            @CurrentUser User user) {
+        reviewService.deleteReview(reviewId, user.getUserId());
         return ResponseEntity.ok(new BaseResponse<>("리뷰가 성공적으로 삭제되었습니다."));
     }
 }

--- a/backend/src/main/java/com/challang/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/challang/backend/user/service/UserService.java
@@ -1,0 +1,27 @@
+package com.challang.backend.user.service;
+
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.user.exception.UserErrorCode;
+import com.challang.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return null;
+    }
+
+
+    public User getByLoginId(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 구현 내용
- `@CurrentUser` 어노테이션 추가  
  - 컨트롤러에서 로그인한 `User` 객체를 직접 주입받을 수 있도록 지원  
  - Swagger 문서에는 노출되지 않도록 `@Parameter(hidden = true)` 설정  

- `CurrentUserResolver` 구현  
  - `Authorization` 헤더에서 JWT 토큰을 추출해 사용자 ID 파싱  
  - `UserService`를 통해 로그인한 유저 조회  

- `WebConfig`에서 `CurrentUserResolver`를 ArgumentResolver로 등록  

- 인증이 필요한 컨트롤러에서 아래와 같이 간편하게 로그인한 사용자 정보를 사용할 수 있습니다:
  ```java
  @Operation(summary = "[테스트] User 가져오기")
  @GetMapping("/me")
  public ResponseEntity<BaseResponse<String>> testCurrentUser(@CurrentUser User user) {
      return ResponseEntity.ok(new BaseResponse<>("Hello, " + user.getUserId()));
  }


---
## 결과 화면

| 상태 | 설명 |
|------|------|
| ✅ 로그인 O | `@CurrentUser`를 통해 유저 정보가 성공적으로 주입되어 `"Hello, {userId}"` 응답을 반환합니다. |
| ❌ 로그인 X | JWT 토큰이 없어 `UNAUTHORIZED_REQUEST` 예외가 발생합니다. |

### ✅ 로그인한 상태
<img width="261" alt="로그인 성공" src="https://github.com/user-attachments/assets/508e2b38-8e70-4644-93da-9beefb4e3acd" />

### ❌ 로그인하지 않은 상태
<img width="382" alt="로그인 실패" src="https://github.com/user-attachments/assets/526b3b65-079f-4ee5-9b6f-8f64641d2e72" />



closes #30