### PR TITLE
feat: 주류에 태그 연결 추가

### DIFF
--- a/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
+++ b/backend/src/main/java/com/challang/backend/liquor/code/LiquorCode.java
@@ -24,6 +24,9 @@ public enum LiquorCode implements ResponseStatus {
     // 도수 관련
     LIQUOR_LEVEL_DELETE_SUCCESS(HttpStatus.OK, true,200,"도수 등급이 성공적으로 삭제되었습니다."),
 
+    INVALID_ABV_RANGE(HttpStatus.BAD_REQUEST, false, 400, "최소 도수는 최대 도수보다 작아야 합니다."),
+    INVALID_ABV_VALUE(HttpStatus.BAD_REQUEST, false, 400, "도수는 0 이상 100 이하의 값이어야 합니다."),
+
     LIQUOR_LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, false,404,"해당 도수 등급을 찾을 수 없습니다."),
     LIQUOR_LEVEL_ALREADY_EXISTS(HttpStatus.CONFLICT, false,409,"이미 존재하는 도수 등급입니다.");
 

--- a/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorCreateRequest.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorCreateRequest.java
@@ -1,8 +1,10 @@
 package com.challang.backend.liquor.dto.request;
 
+import com.challang.backend.tag.dto.request.LiquorTagRequest;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import java.util.List;
 
-// TODO: Tag 추가 예정
 public record LiquorCreateRequest(
 
         @NotBlank(message = "술 이름은 필수입니다.")
@@ -30,6 +32,10 @@ public record LiquorCreateRequest(
         Long levelId,
 
         @NotNull(message = "주종 ID는 필수입니다.")
-        Long typeId
+        Long typeId,
+
+        @NotNull(message = "태그 목록은 필수입니다.")
+        @Size(min = 1, message = "최소 한 개 이상의 태그를 선택해주세요.")
+        List<@Valid LiquorTagRequest> liquorTags
 ) {
 }

--- a/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorUpdateRequest.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorUpdateRequest.java
@@ -1,5 +1,9 @@
 package com.challang.backend.liquor.dto.request;
 
+import com.challang.backend.tag.dto.request.LiquorTagRequest;
+import jakarta.validation.Valid;
+import java.util.List;
+
 public record LiquorUpdateRequest(
 
         String name,
@@ -10,6 +14,7 @@ public record LiquorUpdateRequest(
         Double minAbv,
         Double maxAbv,
         Long levelId,
-        Long typeId
+        Long typeId,
+        List<@Valid LiquorTagRequest> liquorTags
 ) {
 }

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
@@ -1,8 +1,10 @@
 package com.challang.backend.liquor.dto.response;
 
 import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.tag.dto.response.LiquorTagResponse;
+import java.util.List;
 
-// TODO: Tag 추가 예정
+
 public record LiquorResponse(
         Long id,
         String name,
@@ -15,9 +17,14 @@ public record LiquorResponse(
         Long levelId,
         String levelName,
         Long typeId,
-        String typeName
+        String typeName,
+        List<LiquorTagResponse> liquorTags
 ) {
     public static LiquorResponse fromEntity(Liquor liquor) {
+        List<LiquorTagResponse> liquorTags = liquor.getLiquorTags().stream()
+                .map(LiquorTagResponse::fromEntity)
+                .toList();
+
         return new LiquorResponse(
                 liquor.getId(),
                 liquor.getName(),
@@ -30,7 +37,8 @@ public record LiquorResponse(
                 liquor.getLevel().getId(),
                 liquor.getLevel().getName(),
                 liquor.getType().getId(),
-                liquor.getType().getName()
+                liquor.getType().getName(),
+                liquorTags
         );
     }
 

--- a/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
+++ b/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
@@ -2,16 +2,38 @@ package com.challang.backend.liquor.repository;
 
 import com.challang.backend.liquor.entity.Liquor;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LiquorRepository extends JpaRepository<Liquor, Long> {
 
+    @Query("""
+                SELECT DISTINCT l FROM Liquor l
+                LEFT JOIN FETCH l.level
+                LEFT JOIN FETCH l.type
+                LEFT JOIN FETCH l.liquorTags lt
+                LEFT JOIN FETCH lt.tag
+                WHERE l.id = :id
+            """)
+    Optional<Liquor> findWithAllRelationsById(@Param("id") Long id);
+
     boolean existsByName(String name);
+
     boolean existsByNameAndIdNot(String name, Long id);
 
-    List<Liquor> findAllByOrderByNameDesc(Pageable pageable);
-    List<Liquor> findByNameLessThanOrderByNameDesc(String name, Pageable pageable);
+    @Query("""
+                SELECT DISTINCT l FROM Liquor l
+                LEFT JOIN FETCH l.level
+                LEFT JOIN FETCH l.type
+                LEFT JOIN FETCH l.liquorTags lt
+                LEFT JOIN FETCH lt.tag
+                WHERE (:cursor IS NULL OR l.name < :cursor)
+                ORDER BY l.name DESC
+            """)
+    List<Liquor> findAllWithTagsByCursor(@Param("cursor") String cursor, Pageable pageable);
+
 }

--- a/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
+++ b/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
@@ -1,5 +1,7 @@
 package com.challang.backend.liquor.service;
 
+import static com.challang.backend.tag.constant.TagConstant.*;
+
 import com.challang.backend.global.exception.BaseException;
 import com.challang.backend.liquor.code.LiquorCode;
 import com.challang.backend.liquor.dto.request.*;
@@ -28,9 +30,6 @@ public class LiquorService {
     private final LiquorTypeRepository typeRepository;
     private final TagRepository tagRepository;
     private final LiquorTagRepository liquorTagRepository;
-
-    private static final int MIN_CORE_TAG = 2;
-    private static final int MAX_CORE_TAG = 4;
 
     // 주류 추가
     public LiquorResponse create(LiquorCreateRequest request) {

--- a/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
+++ b/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
@@ -2,21 +2,19 @@ package com.challang.backend.liquor.service;
 
 import com.challang.backend.global.exception.BaseException;
 import com.challang.backend.liquor.code.LiquorCode;
-import com.challang.backend.liquor.dto.request.LiquorCreateRequest;
-import com.challang.backend.liquor.dto.request.LiquorUpdateRequest;
-import com.challang.backend.liquor.dto.response.LiquorListResponse;
-import com.challang.backend.liquor.dto.response.LiquorResponse;
-import com.challang.backend.liquor.entity.Liquor;
-import com.challang.backend.liquor.entity.LiquorLevel;
-import com.challang.backend.liquor.entity.LiquorType;
-import com.challang.backend.liquor.repository.LiquorLevelRepository;
-import com.challang.backend.liquor.repository.LiquorRepository;
-import com.challang.backend.liquor.repository.LiquorTypeRepository;
-import java.util.List;
+import com.challang.backend.liquor.dto.request.*;
+import com.challang.backend.liquor.dto.response.*;
+import com.challang.backend.liquor.entity.*;
+import com.challang.backend.liquor.repository.*;
+import com.challang.backend.tag.code.TagCode;
+import com.challang.backend.tag.dto.request.LiquorTagRequest;
+import com.challang.backend.tag.entity.*;
+import com.challang.backend.tag.repository.*;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,19 +26,20 @@ public class LiquorService {
     private final LiquorRepository liquorRepository;
     private final LiquorLevelRepository levelRepository;
     private final LiquorTypeRepository typeRepository;
+    private final TagRepository tagRepository;
+    private final LiquorTagRepository liquorTagRepository;
 
-    // TODO: 태그 추가해야함
+    private static final int MIN_CORE_TAG = 2;
+    private static final int MAX_CORE_TAG = 4;
 
     // 주류 추가
     public LiquorResponse create(LiquorCreateRequest request) {
-        if (liquorRepository.existsByName(request.name())) {
-            throw new BaseException(LiquorCode.LIQUOR_ALREADY_EXISTS);
-        }
+        validateDuplicateName(request.name(), null);
+        validateAbvRange(request.minAbv(), request.maxAbv());
 
-        LiquorLevel level = levelRepository.findById(request.levelId())
-                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_LEVEL_NOT_FOUND));
-        LiquorType type = typeRepository.findById(request.typeId())
-                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_TYPE_NOT_FOUND));
+        // level, type 존재 여부 확인
+        LiquorLevel level = findLevelOrNull(request.levelId());
+        LiquorType type = findTypeOrNull(request.typeId());
 
         Liquor liquor = Liquor.builder()
                 .name(request.name())
@@ -52,8 +51,14 @@ public class LiquorService {
                 .level(level)
                 .type(type)
                 .build();
-
         Liquor saved = liquorRepository.save(liquor);
+
+        // 태그 설정 (핵심 태그는 2~4개)
+        validateCoreTagCount(request.liquorTags());
+        List<LiquorTag> tags = convertToLiquorTags(saved, request.liquorTags());
+        // saved.getLiquorTags().addAll(tags); // 같은 트랜잭션 내 사용 시 필수
+        liquorTagRepository.saveAll(tags);
+
         return LiquorResponse.fromEntity(saved);
     }
 
@@ -66,10 +71,9 @@ public class LiquorService {
     // 주류 전체 조회
     @Transactional(readOnly = true)
     public LiquorListResponse findAll(String cursorName, Integer pageSize) {
-        Pageable pageable = PageRequest.of(0, pageSize + 1);
+        Pageable pageable = PageRequest.of(0, pageSize + 1); // +1: 다음 페이지 여부 확인용
 
-        List<Liquor> liquors = cursorName == null ? liquorRepository.findAllByOrderByNameDesc(pageable)
-                : liquorRepository.findByNameLessThanOrderByNameDesc(cursorName, pageable);
+        List<Liquor> liquors = liquorRepository.findAllWithTagsByCursor(cursorName, pageable);
 
         boolean hasNext = liquors.size() > pageSize;
         if (hasNext) {
@@ -90,26 +94,99 @@ public class LiquorService {
     public LiquorResponse update(Long id, LiquorUpdateRequest request) {
         Liquor liquor = getLiquorById(id);
 
-        if (request.name() != null && liquorRepository.existsByNameAndIdNot(request.name(), id)) {
-            throw new BaseException(LiquorCode.LIQUOR_ALREADY_EXISTS);
+        if (request.name() != null) {
+            validateDuplicateName(request.name(), id);
+        }
+
+        if (request.minAbv() != null || request.maxAbv() != null) {
+            Double minAbv = request.minAbv() != null ? request.minAbv() : liquor.getMinAbv();
+            Double maxAbv = request.maxAbv() != null ? request.maxAbv() : liquor.getMaxAbv();
+            validateAbvRange(minAbv, maxAbv);
         }
 
         LiquorLevel level = findLevelOrNull(request.levelId());
         LiquorType type = findTypeOrNull(request.typeId());
-
         liquor.update(request, level, type);
+
+        // 태그 업데이트
+        if (request.liquorTags() != null) {
+            validateCoreTagCount(request.liquorTags());
+
+            // 기존 태그 제거
+            liquorTagRepository.deleteByLiquorId(liquor.getId());
+
+            // 새 태그 생성
+            List<LiquorTag> updatedTags = convertToLiquorTags(liquor, request.liquorTags());
+
+            // 같은 트랜잭션 내 사용 시 필수
+            // liquor.getLiquorTags().clear();
+            // liquor.getLiquorTags().addAll(updatedTags);
+
+            liquorTagRepository.saveAll(updatedTags);
+        }
+
         return LiquorResponse.fromEntity(liquor);
     }
 
     public void delete(Long id) {
         Liquor liquor = getLiquorById(id);
+        liquorTagRepository.deleteByLiquorId(liquor.getId());
         liquorRepository.delete(liquor);
     }
 
 
+    private List<LiquorTag> convertToLiquorTags(Liquor liquor, List<LiquorTagRequest> liquorTagRequests) {
+        List<Long> tagIds = liquorTagRequests.stream().map(LiquorTagRequest::id).toList();
+        List<Tag> tags = tagRepository.findAllById(tagIds);
+
+        if (tags.size() != tagIds.size()) {
+            throw new BaseException(TagCode.TAG_NOT_FOUND);
+        }
+
+        Map<Long, Tag> tagMap = tags.stream().collect(Collectors.toMap(Tag::getId, Function.identity()));
+
+        return liquorTagRequests.stream()
+                .map(req -> LiquorTag.builder()
+                        .liquor(liquor)
+                        .tag(tagMap.get(req.id()))
+                        .isCore(req.isCore())
+                        .build())
+                .toList();
+    }
+
+    private static void validateCoreTagCount(List<LiquorTagRequest> liquorTagRequests) {
+        long tagCount = liquorTagRequests.stream().filter(LiquorTagRequest::isCore).count();
+
+        if (tagCount < MIN_CORE_TAG || tagCount > MAX_CORE_TAG) {
+            throw new BaseException(TagCode.INVALID_CORE_TAG_COUNT);
+        }
+    }
+
+
+    private void validateDuplicateName(String name, Long excludeId) {
+        boolean exits = excludeId == null
+                ? liquorRepository.existsByName(name)
+                : liquorRepository.existsByNameAndIdNot(name, excludeId);
+
+        if (exits) {
+            throw new BaseException(LiquorCode.LIQUOR_ALREADY_EXISTS);
+        }
+    }
+
+
+    private void validateAbvRange(Double minAbv, Double maxAbv) {
+        if (minAbv > maxAbv) {
+            throw new BaseException(LiquorCode.INVALID_ABV_RANGE);
+        }
+
+        if (minAbv < 0 || maxAbv > 100) {
+            throw new BaseException(LiquorCode.INVALID_ABV_VALUE);
+        }
+    }
+
 
     private Liquor getLiquorById(Long id) {
-        return liquorRepository.findById(id)
+        return liquorRepository.findWithAllRelationsById(id)
                 .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_NOT_FOUND));
     }
 
@@ -128,6 +205,5 @@ public class LiquorService {
         return typeRepository.findById(typeId)
                 .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_TYPE_NOT_FOUND));
     }
-
 
 }

--- a/backend/src/main/java/com/challang/backend/tag/code/TagCode.java
+++ b/backend/src/main/java/com/challang/backend/tag/code/TagCode.java
@@ -13,6 +13,8 @@ public enum TagCode implements ResponseStatus {
     // 태그 관련
     TAG_DELETE_SUCCESS(HttpStatus.OK, true, 200, "태그가 성공적으로 삭제되었습니다."),
 
+    INVALID_CORE_TAG_COUNT(HttpStatus.BAD_REQUEST, false, 4001, "핵심 태그는 2개 이상, 4개 이하여야 합니다."),
+
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 태그를 찾을 수 없습니다."),
     TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 태그입니다.");
 

--- a/backend/src/main/java/com/challang/backend/tag/code/TagCode.java
+++ b/backend/src/main/java/com/challang/backend/tag/code/TagCode.java
@@ -13,10 +13,15 @@ public enum TagCode implements ResponseStatus {
     // 태그 관련
     TAG_DELETE_SUCCESS(HttpStatus.OK, true, 200, "태그가 성공적으로 삭제되었습니다."),
 
-    INVALID_CORE_TAG_COUNT(HttpStatus.BAD_REQUEST, false, 4001, "핵심 태그는 2개 이상, 4개 이하여야 합니다."),
-
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 태그를 찾을 수 없습니다."),
-    TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 태그입니다.");
+    TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, false, 409, "이미 존재하는 태그입니다."),
+
+    // 주류 태그 관련
+    LIQUOR_TAG_DELETE_SUCCESS(HttpStatus.OK, true, 200, "주류 태그가 성공적으로 삭제되었습니다."),
+
+    INVALID_CORE_TAG_COUNT(HttpStatus.BAD_REQUEST, false, 400, "핵심 태그는 2개 이상, 4개 이하여야 합니다."),
+    LIQUOR_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 주류 태그를 찾을 수 없습니다."),
+    LIQUOR_TAG_MISMATCH(HttpStatus.BAD_REQUEST, false, 400, "주류와 해당 태그의 정보가 일치하지 않습니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/backend/src/main/java/com/challang/backend/tag/constant/TagConstant.java
+++ b/backend/src/main/java/com/challang/backend/tag/constant/TagConstant.java
@@ -1,0 +1,8 @@
+package com.challang.backend.tag.constant;
+
+public class TagConstant {
+
+    public static final int MIN_CORE_TAG = 2;
+    public static final int MAX_CORE_TAG = 4;
+
+}

--- a/backend/src/main/java/com/challang/backend/tag/controller/LiquorTagController.java
+++ b/backend/src/main/java/com/challang/backend/tag/controller/LiquorTagController.java
@@ -1,0 +1,61 @@
+package com.challang.backend.tag.controller;
+
+import com.challang.backend.tag.code.TagCode;
+import com.challang.backend.tag.dto.request.LiquorTagRequest;
+import com.challang.backend.tag.dto.response.LiquorTagResponse;
+import com.challang.backend.tag.service.LiquorTagService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "LiquorTag", description = "주류-태그 연결 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/liquors/{liquorId}/tags")
+public class LiquorTagController {
+
+    private final LiquorTagService liquorTagService;
+
+    @Operation(summary = "[관리자] 주류에 태그 추가", description = "특정 주류에 태그를 추가합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주류 태그 추가 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 주류 또는 태그가 존재하지 않음"),
+            @ApiResponse(responseCode = "400", description = "유효성 검사 실패")
+    })
+    @PostMapping
+    public ResponseEntity<BaseResponse<LiquorTagResponse>> create(
+            @PathVariable Long liquorId,
+            @RequestBody @Valid LiquorTagRequest request
+    ) {
+        LiquorTagResponse response = liquorTagService.create(liquorId, request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "특정 주류의 태그 조회", description = "해당 주류에 연결된 태그 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 주류가 존재하지 않음")
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<LiquorTagResponse>>> findByLiquorId(@PathVariable Long liquorId) {
+        List<LiquorTagResponse> response = liquorTagService.findByLiquorId(liquorId);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "[관리자] 주류 태그 삭제", description = "주류에 연결된 특정 태그를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 주류 또는 태그가 존재하지 않음")
+    })
+    @DeleteMapping("/{liquorTagId}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long liquorId, @PathVariable Long liquorTagId) {
+        liquorTagService.delete(liquorId, liquorTagId);
+        return ResponseEntity.ok(new BaseResponse<>(TagCode.LIQUOR_TAG_DELETE_SUCCESS));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/tag/dto/request/LiquorTagRequest.java
+++ b/backend/src/main/java/com/challang/backend/tag/dto/request/LiquorTagRequest.java
@@ -1,0 +1,12 @@
+package com.challang.backend.tag.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LiquorTagRequest(
+        @NotNull(message = "태그 ID는 필수입니다.")
+        Long id,
+
+        @NotNull(message = "핵심 코어여부는 필수입니다.")
+        boolean isCore
+) {
+}

--- a/backend/src/main/java/com/challang/backend/tag/dto/response/LiquorTagResponse.java
+++ b/backend/src/main/java/com/challang/backend/tag/dto/response/LiquorTagResponse.java
@@ -1,0 +1,19 @@
+package com.challang.backend.tag.dto.response;
+
+import com.challang.backend.tag.entity.LiquorTag;
+
+public record LiquorTagResponse(
+        Long tagId,
+        String tagName,
+        boolean isCore
+) {
+
+    public static LiquorTagResponse fromEntity(LiquorTag liquorTag) {
+        return new LiquorTagResponse(
+                liquorTag.getTag().getId(),
+                liquorTag.getTag().getName(),
+                liquorTag.isCore()
+        );
+    }
+
+}

--- a/backend/src/main/java/com/challang/backend/tag/dto/response/LiquorTagResponse.java
+++ b/backend/src/main/java/com/challang/backend/tag/dto/response/LiquorTagResponse.java
@@ -3,6 +3,7 @@ package com.challang.backend.tag.dto.response;
 import com.challang.backend.tag.entity.LiquorTag;
 
 public record LiquorTagResponse(
+        Long id,
         Long tagId,
         String tagName,
         boolean isCore
@@ -10,6 +11,7 @@ public record LiquorTagResponse(
 
     public static LiquorTagResponse fromEntity(LiquorTag liquorTag) {
         return new LiquorTagResponse(
+                liquorTag.getId(),
                 liquorTag.getTag().getId(),
                 liquorTag.getTag().getName(),
                 liquorTag.isCore()

--- a/backend/src/main/java/com/challang/backend/tag/entity/LiquorTag.java
+++ b/backend/src/main/java/com/challang/backend/tag/entity/LiquorTag.java
@@ -26,4 +26,10 @@ public class LiquorTag extends BaseEntity {
     @Column(name = "is_core", nullable = false)
     private boolean isCore; // 핵심적 태그인지
 
+    @Builder
+    public LiquorTag(Liquor liquor, Tag tag, boolean isCore) {
+        this.liquor = liquor;
+        this.tag = tag;
+        this.isCore = isCore;
+    }
 }

--- a/backend/src/main/java/com/challang/backend/tag/repository/LiquorTagRepository.java
+++ b/backend/src/main/java/com/challang/backend/tag/repository/LiquorTagRepository.java
@@ -1,14 +1,17 @@
 package com.challang.backend.tag.repository;
 
 import com.challang.backend.tag.entity.LiquorTag;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LiquorTagRepository extends JpaRepository<LiquorTag, Long> {
+
+    List<LiquorTag> findByLiquorId(Long liquorId);
+    long countByLiquorIdAndIsCoreTrue(Long liquorId);
+
 
     @Modifying
     @Query("DELETE FROM LiquorTag lt WHERE lt.liquor.id = :liquorId")

--- a/backend/src/main/java/com/challang/backend/tag/repository/LiquorTagRepository.java
+++ b/backend/src/main/java/com/challang/backend/tag/repository/LiquorTagRepository.java
@@ -1,0 +1,16 @@
+package com.challang.backend.tag.repository;
+
+import com.challang.backend.tag.entity.LiquorTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LiquorTagRepository extends JpaRepository<LiquorTag, Long> {
+
+    @Modifying
+    @Query("DELETE FROM LiquorTag lt WHERE lt.liquor.id = :liquorId")
+    void deleteByLiquorId(@Param("liquorId") Long liquorId);
+}

--- a/backend/src/main/java/com/challang/backend/tag/service/LiquorTagService.java
+++ b/backend/src/main/java/com/challang/backend/tag/service/LiquorTagService.java
@@ -1,0 +1,95 @@
+package com.challang.backend.tag.service;
+
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.liquor.repository.LiquorRepository;
+import com.challang.backend.tag.code.TagCode;
+import com.challang.backend.tag.dto.request.LiquorTagRequest;
+import com.challang.backend.tag.dto.response.LiquorTagResponse;
+import com.challang.backend.tag.entity.LiquorTag;
+import com.challang.backend.tag.entity.Tag;
+import com.challang.backend.tag.repository.LiquorTagRepository;
+import com.challang.backend.tag.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.challang.backend.tag.constant.TagConstant.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LiquorTagService {
+
+    private final LiquorRepository liquorRepository;
+    private final TagRepository tagRepository;
+    private final LiquorTagRepository liquorTagRepository;
+
+    public LiquorTagResponse create(Long liquorId, LiquorTagRequest request) {
+        Liquor liquor = liquorRepository.findById(liquorId)
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_NOT_FOUND));
+
+        Tag tag = tagRepository.findById(request.id())
+                .orElseThrow(() -> new BaseException(TagCode.TAG_NOT_FOUND));
+
+        validateCoreTagCountOnAdd(liquorId, request.isCore());
+
+        LiquorTag liquorTag = LiquorTag.builder()
+                .liquor(liquor)
+                .tag(tag)
+                .isCore(request.isCore())
+                .build();
+
+        return LiquorTagResponse.fromEntity(liquorTagRepository.save(liquorTag));
+    }
+
+    @Transactional(readOnly = true)
+    public List<LiquorTagResponse> findByLiquorId(Long liquorId) {
+        if (!liquorRepository.existsById(liquorId)) {
+            throw new BaseException(LiquorCode.LIQUOR_NOT_FOUND);
+        }
+
+        List<LiquorTag> liquorTags = liquorTagRepository.findByLiquorId(liquorId);
+        return liquorTags.stream()
+                .map(LiquorTagResponse::fromEntity)
+                .toList();
+    }
+
+    public void delete(Long liquorId, Long liquorTagId) {
+        LiquorTag liquorTag = liquorTagRepository.findById(liquorTagId)
+                .orElseThrow(() -> new BaseException(TagCode.LIQUOR_TAG_NOT_FOUND));
+
+        if (!liquorTag.getLiquor().getId().equals(liquorId)) {
+            throw new BaseException(TagCode.LIQUOR_TAG_MISMATCH);
+        }
+
+        validateCoreTagCountOnDelete(liquorId, liquorTag);
+
+        liquorTagRepository.delete(liquorTag);
+    }
+
+    private void validateCoreTagCountOnAdd(Long liquorId, boolean isCore) {
+        if (!isCore) {
+            return;
+        }
+
+        long coreTagCount = liquorTagRepository.countByLiquorIdAndIsCoreTrue(liquorId);
+        if (coreTagCount >= MAX_CORE_TAG) {
+            throw new BaseException(TagCode.INVALID_CORE_TAG_COUNT);
+        }
+    }
+
+    private void validateCoreTagCountOnDelete(Long liquorId, LiquorTag liquorTag) {
+        if (!liquorTag.isCore()) {
+            return;
+        }
+
+        long coreTagCount = liquorTagRepository.countByLiquorIdAndIsCoreTrue(liquorId);
+        if (coreTagCount <= MIN_CORE_TAG) {
+            throw new BaseException(TagCode.INVALID_CORE_TAG_COUNT);
+        }
+    }
+}


### PR DESCRIPTION
## 🍶 주류-태그 연결 기능 추가

### ✅ 주요 변경사항
- 주류와 태그를 연결하는 `LiquorTag` 엔티티 및 관련 CRUD 기능 구현
- 주류 등록/수정 시 태그를 함께 처리할 수 있도록 서비스 로직 수정
- 핵심 태그(core)는 최소 2개, 최대 4개 제한 → 유효성 검증 추가
- 주류 응답 DTO에 태그 리스트 포함
- **N+1 문제 방지**를 위한 fetch join 적용
- **대량 삭제 최적화**를 위한 JPQL 삭제 쿼리 적용

---

### ✅ N+1 문제 방지

- 주류 단건 조회(`findById`) 및 전체 조회(`findAllWithTagsByCursor`) 시 관련 연관 엔티티(`LiquorTag`, `Tag`, `LiquorLevel`, `LiquorType`)를 **fetch join**으로 조회합니다.
- 이를 통해 반복 조회 시 매번 쿼리가 날아가는 **N+1 문제를 사전에 방지**합니다.

```java
@Query("""
    SELECT DISTINCT l FROM Liquor l
    LEFT JOIN FETCH l.level
    LEFT JOIN FETCH l.type
    LEFT JOIN FETCH l.liquorTags lt
    LEFT JOIN FETCH lt.tag
    WHERE l.id = :id
""")
Optional<Liquor> findWithAllRelationsById(@Param("id") Long id);
```
---

### ✅ 대량 삭제 시 JPQL 사용으로 성능 최적화

- 주류 수정/삭제 시 기존에 연결된 **모든 태그를 한 번에 삭제**해야 하므로, 단일 쿼리로 처리하여 **성능을 최적화**했습니다.
- `LiquorTagRepository`에 아래와 같이 **JPQL 기반 대량 삭제 쿼리**를 정의했습니다.

```java
@Modifying
@Query("DELETE FROM LiquorTag lt WHERE lt.liquor.id = :liquorId")
void deleteByLiquorId(@Param("liquorId") Long liquorId);
```



closes #22

