### PR TITLE
feat: 아카이브 등록/해제 및 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/archive/code/ArchiveCode.java
+++ b/backend/src/main/java/com/challang/backend/archive/code/ArchiveCode.java
@@ -1,0 +1,23 @@
+package com.challang.backend.archive.code;
+
+import com.challang.backend.util.response.ResponseStatus;
+import lombok.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum ArchiveCode implements ResponseStatus {
+
+    ARCHIVE_SUCCESS(HttpStatus.OK, true, 2400, "아카이브 등록에 성공했습니다."),
+    UNARCHIVE_SUCCESS(HttpStatus.OK, true, 2405, "아카이브 해제에 성공했습니다."),
+
+    ALREADY_ARCHIVED(HttpStatus.BAD_REQUEST, false, 400, "이미 아카이빙된 술입니다."),
+    ARCHIVE_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 아카이브 정보를 찾을 수 없습니다.");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+
+}

--- a/backend/src/main/java/com/challang/backend/archive/controller/ArchiveController.java
+++ b/backend/src/main/java/com/challang/backend/archive/controller/ArchiveController.java
@@ -1,0 +1,67 @@
+package com.challang.backend.archive.controller;
+
+import com.challang.backend.archive.code.ArchiveCode;
+import com.challang.backend.archive.dto.response.ArchiveListResponse;
+import com.challang.backend.archive.service.ArchiveService;
+import com.challang.backend.auth.annotation.CurrentUser;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Archive", description = "아카이브 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/archive")
+public class ArchiveController {
+
+    private final ArchiveService archiveService;
+
+    @Operation(summary = "아카이브 목록 조회", description = "로그인 유저의 아카이브한 술들을 커서 기반으로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse<ArchiveListResponse>> getArchivedByCursor(
+            @CurrentUser User user,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        ArchiveListResponse response = archiveService.findAll(user.getUserId(), cursor, keyword, size);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "술 아카이브 등록", description = "특정 술을 아카이브에 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 등록된 경우"),
+            @ApiResponse(responseCode = "404", description = "술 또는 유저를 찾을 수 없음")
+    })
+    @PostMapping("/{liquorId}")
+    public ResponseEntity<BaseResponse<Void>> archiveLiquor(
+            @CurrentUser User user,
+            @PathVariable Long liquorId
+    ) {
+        archiveService.archiveLiquor(user.getUserId(), liquorId);
+        return ResponseEntity.ok(new BaseResponse<>(ArchiveCode.ARCHIVE_SUCCESS));
+    }
+
+    @Operation(summary = "술 아카이브 해제", description = "특정 술을 아카이브에서 제거합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "해제 성공"),
+            @ApiResponse(responseCode = "404", description = "등록되지 않은 아카이브")
+    })
+    @DeleteMapping("/{liquorId}")
+    public ResponseEntity<BaseResponse<Void>> unarchiveLiquor(
+            @CurrentUser User user,
+            @PathVariable Long liquorId
+    ) {
+        archiveService.unarchiveLiquor(user.getUserId(), liquorId);
+        return ResponseEntity.ok(new BaseResponse<>(ArchiveCode.UNARCHIVE_SUCCESS));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/archive/dto/response/ArchiveListResponse.java
+++ b/backend/src/main/java/com/challang/backend/archive/dto/response/ArchiveListResponse.java
@@ -1,0 +1,11 @@
+package com.challang.backend.archive.dto.response;
+
+import com.challang.backend.liquor.entity.Liquor;
+import java.util.List;
+
+public record ArchiveListResponse(
+        List<Liquor> items,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/backend/src/main/java/com/challang/backend/archive/entity/Archive.java
+++ b/backend/src/main/java/com/challang/backend/archive/entity/Archive.java
@@ -24,4 +24,10 @@ public class Archive extends BaseEntity {
     @JoinColumn(name = "liquor_id", nullable = false)
     private Liquor liquor;
 
+
+    @Builder
+    public Archive(User user, Liquor liquor) {
+        this.user = user;
+        this.liquor = liquor;
+    }
 }

--- a/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
+++ b/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
@@ -1,0 +1,47 @@
+package com.challang.backend.archive.repository;
+
+import com.challang.backend.archive.entity.Archive;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArchiveRepository extends JpaRepository<Archive, Long> {
+
+
+    Optional<Archive> findByUserAndLiquor(User user, Liquor liquor);
+    boolean existsByUserAndLiquor(User user, Liquor liquor);
+
+    @Modifying
+    @Query("DELETE FROM Archive a WHERE a.user = :user AND a.liquor = :liquor")
+    int deleteByUserAndLiquor(@Param("user") User user, @Param("liquor") Liquor liquor);
+
+    @Query("""
+                SELECT DISTINCT a.liquor
+                FROM Archive a
+                JOIN a.liquor l
+                LEFT JOIN l.liquorTags lt
+                LEFT JOIN lt.tag t
+                WHERE a.user.userId = :userId
+                AND (
+                    :keyword IS NULL
+                    OR LOWER(l.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                    OR LOWER(t.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                )
+                AND (:cursor IS NULL OR a.id < :cursor)
+                ORDER BY a.id DESC
+            """)
+    List<Liquor> findArchivedLiquorsByCursor(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+};

--- a/backend/src/main/java/com/challang/backend/archive/service/ArchiveService.java
+++ b/backend/src/main/java/com/challang/backend/archive/service/ArchiveService.java
@@ -1,0 +1,84 @@
+package com.challang.backend.archive.service;
+
+import com.challang.backend.archive.code.ArchiveCode;
+import com.challang.backend.archive.dto.response.ArchiveListResponse;
+import com.challang.backend.archive.entity.Archive;
+import com.challang.backend.archive.repository.ArchiveRepository;
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.liquor.repository.LiquorRepository;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.user.exception.UserErrorCode;
+import com.challang.backend.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ArchiveService {
+
+    private final ArchiveRepository archiveRepository;
+    private final UserRepository userRepository;
+    private final LiquorRepository liquorRepository;
+
+
+    // 아카이브 읽기
+    @Transactional(readOnly = true)
+    public ArchiveListResponse findAll(Long userId, Long cursorId, String keyword, Integer pageSize) {
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
+
+        List<Liquor> liquors = archiveRepository.findArchivedLiquorsByCursor(userId, keyword, cursorId, pageable);
+
+        boolean hasNext = liquors.size() > pageSize;
+        if (hasNext) {
+            liquors = liquors.subList(0, pageSize);
+        }
+
+        Long nextCursor = hasNext ? liquors.get(liquors.size() - 1).getId() : null;
+        return new ArchiveListResponse(liquors, nextCursor, hasNext);
+    }
+
+
+    // 아카이브 생성
+    public void archiveLiquor(Long userId, Long liquorId) {
+        User user = getUserById(userId);
+        Liquor liquor = getLiquorById(liquorId);
+
+        if (archiveRepository.existsByUserAndLiquor(user, liquor)) {
+            throw new BaseException(ArchiveCode.ALREADY_ARCHIVED);
+        }
+
+        Archive archive = Archive.builder()
+                .user(user)
+                .liquor(liquor)
+                .build();
+        archiveRepository.save(archive);
+    }
+
+    // 아카이브 삭제
+    public void unarchiveLiquor(Long userId, Long liquorId) {
+        User user = getUserById(userId);
+        Liquor liquor = getLiquorById(liquorId);
+        int deletedCount = archiveRepository.deleteByUserAndLiquor(user, liquor);
+        if (deletedCount == 0) {
+            throw new BaseException(ArchiveCode.ARCHIVE_NOT_FOUND);
+        }
+    }
+
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private Liquor getLiquorById(Long liquorId) {
+        return liquorRepository.findById(liquorId)
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항

### ✅ 기능 구현
- `POST /api/archive/{liquorId}`  
  → 로그인한 유저가 특정 술을 아카이브에 등록
- `DELETE /api/archive/{liquorId}`  
  → 아카이브에서 해당 술 해제
- `GET /api/archive`  
  → 검색어와 커서를 기준으로 아카이브된 술 목록 조회



closes #29 