### PR TITLE
feat: S3 이미지 업로드 기능 및 리뷰/술 이미지 연동

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation platform('software.amazon.awssdk:bom:2.20.56')
+	implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/challang/backend/file/controller/FileController.java
+++ b/backend/src/main/java/com/challang/backend/file/controller/FileController.java
@@ -1,0 +1,34 @@
+package com.challang.backend.file.controller;
+
+import com.challang.backend.file.dto.PresignedUrlResponse;
+import com.challang.backend.file.service.FileService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "File", description = "S3 Presigned URL 발급 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/files")
+public class FileController {
+
+    private final FileService fileService;
+
+    @Operation(summary = "Presigned URL 발급", description = "S3에 직접 업로드할 수 있는 URL과 저장할 Key를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Presigned URL 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 파라미터 오류")
+    })
+    @GetMapping("/upload-url")
+    public ResponseEntity<BaseResponse<PresignedUrlResponse>> getUploadUrl(
+            @RequestParam String domain,
+            @RequestParam String filename
+    ) {
+        PresignedUrlResponse response = fileService.getPresignedUploadUrl(domain, filename);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/file/dto/PresignedUrlResponse.java
+++ b/backend/src/main/java/com/challang/backend/file/dto/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.challang.backend.file.dto;
+
+public record PresignedUrlResponse(
+        String presignedUrl,
+        String key
+) {
+}

--- a/backend/src/main/java/com/challang/backend/file/service/FileService.java
+++ b/backend/src/main/java/com/challang/backend/file/service/FileService.java
@@ -1,0 +1,25 @@
+package com.challang.backend.file.service;
+
+
+import com.challang.backend.file.dto.PresignedUrlResponse;
+import com.challang.backend.util.aws.service.S3Service;
+import java.net.URL;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final S3Service s3Service;
+
+    public PresignedUrlResponse getPresignedUploadUrl(String domain, String originalFilename) {
+        String uniqueFilename = UUID.randomUUID() + "_" + originalFilename;
+        String key = s3Service.buildS3Key(domain, uniqueFilename);
+        URL url = s3Service.generatePresignedUrl(key);
+        return new PresignedUrlResponse(url.toString(), key);
+    }
+
+
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorCreateRequest.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/request/LiquorCreateRequest.java
@@ -10,7 +10,7 @@ public record LiquorCreateRequest(
         @NotBlank(message = "술 이름은 필수입니다.")
         String name,
 
-        // TODO: 나중에 필수로 추가하기
+        @NotBlank(message = "술 이미지는 필수입니다.")
         String imageUrl,
 
         @NotBlank(message = "베이스는 필수입니다. 어떤 원료로 만들어졌는지 입력해주세요. (예: 쌀, 보리 등)")

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
@@ -20,15 +20,17 @@ public record LiquorResponse(
         String typeName,
         List<LiquorTagResponse> liquorTags
 ) {
-    public static LiquorResponse fromEntity(Liquor liquor) {
+    public static LiquorResponse fromEntity(Liquor liquor, String s3BaseUrl) {
         List<LiquorTagResponse> liquorTags = liquor.getLiquorTags().stream()
                 .map(LiquorTagResponse::fromEntity)
                 .toList();
 
+        String fullImageUrl = s3BaseUrl + "/" + liquor.getImageUrl();
+
         return new LiquorResponse(
                 liquor.getId(),
                 liquor.getName(),
-                liquor.getImageUrl(),
+                fullImageUrl,
                 liquor.getBase(),
                 liquor.getOrigin(),
                 liquor.getColor(),

--- a/backend/src/main/java/com/challang/backend/liquor/entity/Liquor.java
+++ b/backend/src/main/java/com/challang/backend/liquor/entity/Liquor.java
@@ -28,8 +28,7 @@ public class Liquor extends BaseEntity {
     @Column(name = "name", nullable = false, unique = true)
     private String name;
 
-    // TODO: 나중에 이미지 추가
-    @Column(name = "image_url")
+    @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
     @Column(name = "base", nullable = false)

--- a/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Review API", description = "리뷰 관련 API")
+@Tag(name = "Review", description = "리뷰 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")

--- a/backend/src/main/java/com/challang/backend/review/dto/request/ReviewCreateRequestDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/request/ReviewCreateRequestDto.java
@@ -2,9 +2,11 @@ package com.challang.backend.review.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-// record를 사용해 불변 객체로 간단히 정의
 public record ReviewCreateRequestDto(
         @NotBlank(message = "리뷰 내용은 필수 입력값입니다.")
-        String content
+        String content,
+
+        @NotBlank(message = "리뷰 이미지는 필수입니다.")
+        String imageUrl
 ) {
 }

--- a/backend/src/main/java/com/challang/backend/review/dto/request/ReviewUpdateRequestDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/request/ReviewUpdateRequestDto.java
@@ -1,9 +1,7 @@
 package com.challang.backend.review.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record ReviewUpdateRequestDto(
-        @NotBlank(message = "리뷰 내용은 비울 수 없습니다.")
-        String content
+        String content,
+        String imageUrl
 ) {
 }

--- a/backend/src/main/java/com/challang/backend/review/dto/response/ReviewResponseDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/response/ReviewResponseDto.java
@@ -8,15 +8,17 @@ public record ReviewResponseDto(
         Long writerId,
         String writerNickname,
         String content,
+        String imageUrl,
         LocalDateTime createdAt
 ) {
-    // Entity를 DTO로 변환하는 정적 팩토리 메서드
-    public static ReviewResponseDto from(Review review) {
+    public static ReviewResponseDto from(Review review, String s3BaseUrl) {
+        String fullImageUrl = s3BaseUrl + "/" + review.getImageUrl();
         return new ReviewResponseDto(
                 review.getId(),
                 review.getWriter().getUserId(),
                 review.getWriter().getNickname(),
                 review.getContent(),
+                fullImageUrl,
                 review.getCreatedAt()
         );
     }

--- a/backend/src/main/java/com/challang/backend/review/entity/Review.java
+++ b/backend/src/main/java/com/challang/backend/review/entity/Review.java
@@ -1,7 +1,7 @@
 package com.challang.backend.review.entity;
 
 import com.challang.backend.liquor.entity.Liquor;
-import com.challang.backend.liquor.entity.LiquorType;
+import com.challang.backend.review.dto.request.ReviewUpdateRequestDto;
 import com.challang.backend.user.entity.User;
 import com.challang.backend.util.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -25,16 +25,22 @@ public class Review extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "liquor_id", nullable = false)
-    private LiquorType liquor;
+    private Liquor liquor;
 
     @Column(name = "content", nullable = false)
     private String content;
 
-    @Column(name = "image_url") // nullable = false 제거
-    @Builder.Default // 빌더 사용 시 기본값 설정
-    private String imageUrl = ""; // 기본값을 빈 문자열로 설정
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
 
-    public void updateContent(String newContent) {
-        this.content = newContent;
+    public void update(ReviewUpdateRequestDto request) {
+        if (request.content() != null) {
+            this.content = request.content();
+        }
+        if (request.imageUrl() != null) {
+            this.imageUrl = request.imageUrl();
+        }
     }
+
+
 }

--- a/backend/src/main/java/com/challang/backend/review/exception/ReviewErrorCode.java
+++ b/backend/src/main/java/com/challang/backend/review/exception/ReviewErrorCode.java
@@ -1,42 +1,19 @@
 package com.challang.backend.review.exception;
 
 import com.challang.backend.util.response.ResponseStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode; // HttpStatus 대신 HttpStatusCode import
+import lombok.*;
+import org.springframework.http.*;
 
 @Getter
 @AllArgsConstructor
 public enum ReviewErrorCode implements ResponseStatus {
 
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 리뷰를 찾을 수 없습니다."),
-    NO_AUTHORITY_FOR_REVIEW(HttpStatus.FORBIDDEN, false, 403, "해당 리뷰에 대한 수정/삭제 권한이 없습니다."),
-    LIQUOR_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "리뷰를 작성하려는 주류를 찾을 수 없습니다.");
+    NO_AUTHORITY_FOR_REVIEW(HttpStatus.FORBIDDEN, false, 403, "해당 리뷰에 대한 수정/삭제 권한이 없습니다.");
 
-    private final HttpStatusCode httpStatusCode; // HttpStatus -> HttpStatusCode 로 변경
+    private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;
     private final int code;
     private final String message;
 
-    // ResponseStatus 인터페이스의 모든 추상 메서드를 올바르게 구현
-    @Override
-    public int getCode() {
-        return this.code;
-    }
-
-    @Override
-    public HttpStatusCode getHttpStatusCode() {
-        return this.httpStatusCode;
-    }
-
-    @Override
-    public String getMessage() {
-        return this.message;
-    }
-
-    @Override
-    public boolean isSuccess() {
-        return this.isSuccess;
-    }
 }

--- a/backend/src/main/java/com/challang/backend/review/exception/ReviewException.java
+++ b/backend/src/main/java/com/challang/backend/review/exception/ReviewException.java
@@ -1,9 +1,0 @@
-package com.challang.backend.review.exception;
-
-import com.challang.backend.global.exception.BaseException;
-
-public class ReviewException extends BaseException {
-    public ReviewException(ReviewErrorCode reviewErrorCode) {
-        super(reviewErrorCode);
-    }
-}

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
@@ -1,10 +1,15 @@
 package com.challang.backend.review.repository;
 
 import com.challang.backend.review.entity.Review;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import org.springframework.data.jpa.repository.*;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    // 특정 주류(Liquor)에 달린 모든 리뷰를 찾기 위한 메서드
     List<Review> findByLiquorIdOrderByIdDesc(Long liquorId);
+
+    @Modifying
+    @Query("DELETE FROM Review r WHERE r.liquor.id = :liquorId")
+    void deleteByLiquorId(@Param("liquorId") Long liquorId);
 }

--- a/backend/src/main/java/com/challang/backend/util/aws/config/S3Config.java
+++ b/backend/src/main/java/com/challang/backend/util/aws/config/S3Config.java
@@ -1,0 +1,42 @@
+package com.challang.backend.util.aws.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.*;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AwsCredentialsProvider awsCredentialsProvider() {
+        AwsCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return StaticCredentialsProvider.create(awsCredentials);
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(awsCredentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(awsCredentialsProvider())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/challang/backend/util/aws/service/S3Service.java
+++ b/backend/src/main/java/com/challang/backend/util/aws/service/S3Service.java
@@ -1,0 +1,81 @@
+package com.challang.backend.util.aws.service;
+
+
+import java.net.URL;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private static final String BASE_PREFIX = "images";
+
+    // S3에 업로드하기 위한 Presigned URL을 생성
+    public URL generatePresignedUrl(String key) {
+        String contentType = detectContentType(key);
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest =
+                s3Presigner.presignPutObject(builder ->
+                        builder.putObjectRequest(objectRequest)
+                                .signatureDuration(Duration.ofMinutes(10)));
+
+        return presignedRequest.url();
+    }
+
+    // 파일 삭제
+    public void deleteByKey(String key) {
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+        s3Client.deleteObject(deleteRequest);
+    }
+
+
+    // S3 저장 경로 생성
+    public String buildS3Key(String domain, String filename) {
+        return BASE_PREFIX + "/" + domain + "/" + filename;
+    }
+
+    // content-type 추출
+    private String detectContentType(String filename) {
+        String extension = "";
+        int idx = filename.lastIndexOf('.');
+        if (idx != -1) {
+            extension = filename.substring(idx + 1).toLowerCase();
+        }
+
+        return switch (extension) {
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "webp" -> "image/webp";
+            case "gif" -> "image/gif";
+            case "heic" -> "image/heic";
+            case "svg" -> "image/svg+xml";
+            default -> "application/octet-stream"; // 기본값 (불명확할 때)
+        };
+    }
+
+}


### PR DESCRIPTION
##  기능 추가: Presigned URL 기반 S3 이미지 업로드 기능 구현

### 📌 구현 내용
- S3에 직접 업로드 가능한 **Presigned URL 발급 API** 추가
  - `GET /api/files/upload-url?domain={도메인}&filename={파일명}`
  - 응답: `presignedUrl`, `key`
- S3Service를 통해 업로드용 Key 생성 및 Content-Type 자동 판별
- Liquor/Review 이미지 관련 로직 개선
  - fullImageUrl = s3BaseUrl + "/" + key
  - 이미지 응답 DTO에 full URL 포함
- Liquor/Review 삭제 시 관련 이미지 S3에서 함께 삭제

### ⚙️ 기타
- 의존성 추가: `software.amazon.awssdk:s3`, `bom:2.20.56`
- Swagger 문서에 Presigned URL API 포함
