### PR TITLE
feat: 피드백 기능 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/feedback/code/FeedbackCode.java
+++ b/backend/src/main/java/com/challang/backend/feedback/code/FeedbackCode.java
@@ -1,0 +1,22 @@
+package com.challang.backend.feedback.code;
+
+import com.challang.backend.util.response.ResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum FeedbackCode implements ResponseStatus {
+
+    FEEDBACK_SAVED(HttpStatus.OK, true, 200, "피드백 저장에 성공했습니다."),
+    FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "피드백을 찾을 수 없습니다."),
+
+    INVALID_FEEDBACK_TYPE(HttpStatus.BAD_REQUEST, false, 400, "유효하지 않은 피드백 타입입니다.");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+}

--- a/backend/src/main/java/com/challang/backend/feedback/controller/FeedbackController.java
+++ b/backend/src/main/java/com/challang/backend/feedback/controller/FeedbackController.java
@@ -1,0 +1,39 @@
+package com.challang.backend.feedback.controller;
+
+import com.challang.backend.auth.annotation.CurrentUser;
+import com.challang.backend.feedback.dto.FeedbackRequest;
+import com.challang.backend.feedback.dto.FeedbackResponse;
+import com.challang.backend.feedback.service.FeedbackService;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Feedback", description = "피드백 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feedback")
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @Operation(summary = "피드백 등록/수정", description = "특정 술에 대해 피드백을 등록하거나 수정합니다. 이미 등록된 피드백이 있다면 type만 변경됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "피드백 등록 또는 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값이 잘못된 경우 (예: 잘못된 enum 값)"),
+            @ApiResponse(responseCode = "404", description = "해당 술을 찾을 수 없음")
+    })
+    @PostMapping
+    public ResponseEntity<BaseResponse<FeedbackResponse>> saveFeedback(
+            @CurrentUser User user,
+            @RequestBody @Valid FeedbackRequest request
+    ) {
+        FeedbackResponse response = feedbackService.saveFeedback(user, request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/feedback/converter/FeedbackTypeConverter.java
+++ b/backend/src/main/java/com/challang/backend/feedback/converter/FeedbackTypeConverter.java
@@ -1,0 +1,19 @@
+package com.challang.backend.feedback.converter;
+
+import com.challang.backend.feedback.entity.FeedbackType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class FeedbackTypeConverter implements AttributeConverter<FeedbackType, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(FeedbackType attribute) {
+        return attribute != null ? attribute.getCode() : null;
+    }
+
+    @Override
+    public FeedbackType convertToEntityAttribute(Integer dbData) {
+        return dbData != null ? FeedbackType.fromCode(dbData) : null;
+    }
+}

--- a/backend/src/main/java/com/challang/backend/feedback/dto/FeedbackRequest.java
+++ b/backend/src/main/java/com/challang/backend/feedback/dto/FeedbackRequest.java
@@ -1,0 +1,12 @@
+package com.challang.backend.feedback.dto;
+
+import com.challang.backend.feedback.entity.FeedbackType;
+import jakarta.validation.constraints.*;
+
+public record FeedbackRequest(
+        @NotNull(message = "liquorId는 필수입니다.")
+        Long liquorId,
+
+        @NotNull(message = "피드백 타입은 필수입니다.")
+        FeedbackType type) {
+}

--- a/backend/src/main/java/com/challang/backend/feedback/dto/FeedbackResponse.java
+++ b/backend/src/main/java/com/challang/backend/feedback/dto/FeedbackResponse.java
@@ -1,0 +1,9 @@
+package com.challang.backend.feedback.dto;
+
+import com.challang.backend.feedback.entity.FeedbackType;
+
+public record FeedbackResponse(
+        Long liquorId,
+        FeedbackType type
+) {
+}

--- a/backend/src/main/java/com/challang/backend/feedback/entity/FeedbackType.java
+++ b/backend/src/main/java/com/challang/backend/feedback/entity/FeedbackType.java
@@ -1,0 +1,36 @@
+package com.challang.backend.feedback.entity;
+
+import com.challang.backend.feedback.code.FeedbackCode;
+import com.challang.backend.global.exception.BaseException;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "피드백 타입 (GOOD: 좋음, BAD: 나쁨)")
+public enum FeedbackType {
+    GOOD(0, "Good"),
+    BAD(1, "Bad");
+
+    private final int code;
+    private final String label;
+
+    FeedbackType(int code, String label) {
+        this.code = code;
+        this.label = label;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public static FeedbackType fromCode(int code) {
+        for (FeedbackType type : values()) {
+            if (type.code == code) {
+                return type;
+            }
+        }
+        throw new BaseException(FeedbackCode.INVALID_FEEDBACK_TYPE);
+    }
+}

--- a/backend/src/main/java/com/challang/backend/feedback/entity/LiquorFeedback.java
+++ b/backend/src/main/java/com/challang/backend/feedback/entity/LiquorFeedback.java
@@ -1,0 +1,41 @@
+package com.challang.backend.feedback.entity;
+
+import com.challang.backend.feedback.converter.FeedbackTypeConverter;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.util.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "liquor_feedback", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "liquor_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiquorFeedback extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "liquor_id", nullable = false)
+    private Liquor liquor;
+
+    @Convert(converter = FeedbackTypeConverter.class)
+    private FeedbackType type;
+
+    @Builder
+    public LiquorFeedback(User user, Liquor liquor, FeedbackType type) {
+        this.user = user;
+        this.liquor = liquor;
+        this.type = type;
+    }
+
+    public void updateType(FeedbackType type) {
+        this.type = type;
+    }
+}

--- a/backend/src/main/java/com/challang/backend/feedback/repository/LiquorFeedbackRepository.java
+++ b/backend/src/main/java/com/challang/backend/feedback/repository/LiquorFeedbackRepository.java
@@ -1,0 +1,18 @@
+package com.challang.backend.feedback.repository;
+
+import com.challang.backend.feedback.entity.LiquorFeedback;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface LiquorFeedbackRepository extends JpaRepository<LiquorFeedback, Long> {
+    List<LiquorFeedback> findByUser(User user);
+
+    Optional<LiquorFeedback> findByUserAndLiquor(User user, Liquor liquor);
+
+}

--- a/backend/src/main/java/com/challang/backend/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/challang/backend/feedback/service/FeedbackService.java
@@ -1,0 +1,45 @@
+package com.challang.backend.feedback.service;
+
+
+import com.challang.backend.feedback.dto.*;
+import com.challang.backend.feedback.entity.*;
+import com.challang.backend.feedback.repository.LiquorFeedbackRepository;
+import com.challang.backend.global.exception.BaseException;
+import com.challang.backend.liquor.code.LiquorCode;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.liquor.repository.LiquorRepository;
+import com.challang.backend.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+
+    private final LiquorRepository liquorRepository;
+    private final LiquorFeedbackRepository feedbackRepository;
+
+
+    public FeedbackResponse saveFeedback(User user, FeedbackRequest request) {
+        Liquor liquor = liquorRepository.findById(request.liquorId())
+                .orElseThrow(() -> new BaseException(LiquorCode.LIQUOR_NOT_FOUND));
+
+        FeedbackType type = request.type();
+
+        feedbackRepository.findByUserAndLiquor(user, liquor)
+                .ifPresentOrElse(
+                        feedback -> feedback.updateType(type),
+                        () -> feedbackRepository.save(
+                                LiquorFeedback.builder()
+                                        .user(user)
+                                        .liquor(liquor)
+                                        .type(type)
+                                        .build()
+                        )
+                );
+
+        return new FeedbackResponse(liquor.getId(), type);
+
+    }
+
+}


### PR DESCRIPTION
## 📌 개요
사용자가 특정 술에 대해 **GOOD / BAD 피드백**을 등록하거나 수정할 수 있는 기능 구현 
이미 피드백이 존재할 경우 `type`만 갱신되며, 없을 경우 새로 저장

---

## ✨ 주요 변경 사항
- `POST /api/feedback` API 구현
  - 요청값: `liquorId`, `type` (GOOD 또는 BAD)
- `LiquorFeedback` 엔티티 생성
  - 유저 & 술 조합은 유니크하게 관리
- `FeedbackType` enum ↔ DB 정수 변환용 `FeedbackTypeConverter` 구현
- DTO 정의
  - `FeedbackRequest`, `FeedbackResponse`
- 예외 처리
  - 존재하지 않는 술 ID → 404
  - 잘못된 피드백 타입 → 400
---

closes #40 
