### PR TITLE
feat: 선호 기반 술 추천 기능 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
+++ b/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
@@ -44,4 +44,7 @@ public interface ArchiveRepository extends JpaRepository<Archive, Long> {
             @Param("cursor") Long cursor,
             Pageable pageable
     );
+
+    // 술 id만 얻는 용도 => joinX
+    List<Archive> findByUser(User user);
 };

--- a/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
+++ b/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
@@ -3,6 +3,7 @@ package com.challang.backend.liquor.repository;
 import com.challang.backend.liquor.entity.Liquor;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
@@ -35,5 +36,17 @@ public interface LiquorRepository extends JpaRepository<Liquor, Long> {
                 ORDER BY l.name DESC
             """)
     List<Liquor> findAllWithTagsByCursor(@Param("cursor") String cursor, Pageable pageable);
+
+    @Query("""
+                SELECT DISTINCT l FROM Liquor l
+                LEFT JOIN FETCH l.level
+                LEFT JOIN FETCH l.type
+                LEFT JOIN FETCH l.liquorTags lt
+                LEFT JOIN FETCH lt.tag
+                WHERE l.type.id IN :typeIds AND l.level.id IN :levelIds
+            """)
+    List<Liquor> findWithTagsByTypeAndLevel(@Param("typeIds") Set<Long> typeIds,
+                                            @Param("levelIds") Set<Long> levelIds);
+
 
 }

--- a/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceLevelRepository.java
+++ b/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceLevelRepository.java
@@ -2,9 +2,12 @@ package com.challang.backend.preference.repository;
 
 
 import com.challang.backend.preference.entity.LiquorPreferenceLevel;
+import com.challang.backend.user.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LiquorPreferenceLevelRepository extends JpaRepository<LiquorPreferenceLevel, Long> {
+    List<LiquorPreferenceLevel> findByUser(User user);
 }

--- a/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTagRepository.java
+++ b/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTagRepository.java
@@ -3,10 +3,13 @@ package com.challang.backend.preference.repository;
 import com.challang.backend.tag.entity.Tag;
 import com.challang.backend.user.entity.User;
 import com.challang.backend.preference.entity.LiquorPreferenceTag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LiquorPreferenceTagRepository extends JpaRepository<LiquorPreferenceTag, Long> {
     boolean existsByUserAndTag(User user, Tag tag);
+
+    List<LiquorPreferenceTag> findByUser(User user);
 }

--- a/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTypeRepository.java
+++ b/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTypeRepository.java
@@ -4,11 +4,14 @@ package com.challang.backend.preference.repository;
 import com.challang.backend.liquor.entity.LiquorType;
 import com.challang.backend.user.entity.User;
 import com.challang.backend.preference.entity.LiquorPreferenceType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LiquorPreferenceTypeRepository extends JpaRepository<LiquorPreferenceType, Long> {
     boolean existsByUserAndLiquorType(User user, LiquorType liquorType);
+
+    List<LiquorPreferenceType> findByUser(User user);
 
 }

--- a/backend/src/main/java/com/challang/backend/recommend/controller/RecommendController.java
+++ b/backend/src/main/java/com/challang/backend/recommend/controller/RecommendController.java
@@ -1,0 +1,35 @@
+package com.challang.backend.recommend.controller;
+
+import com.challang.backend.auth.annotation.CurrentUser;
+import com.challang.backend.liquor.dto.response.LiquorResponse;
+import com.challang.backend.recommend.service.RecommendService;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Recommend", description = "추천 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/recommend")
+public class RecommendController {
+
+    private final RecommendService recommendService;
+
+    @Operation(summary = "술 추천", description = "선호도와 피드백 기반 추천 술 리스트를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "추천 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<LiquorResponse>>> getRecommendList(
+            @CurrentUser User user
+    ) {
+        List<LiquorResponse> response = recommendService.recommendLiquor(user);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/recommend/service/RecommendService.java
+++ b/backend/src/main/java/com/challang/backend/recommend/service/RecommendService.java
@@ -1,0 +1,104 @@
+package com.challang.backend.recommend.service;
+
+import com.challang.backend.archive.repository.ArchiveRepository;
+import com.challang.backend.feedback.repository.LiquorFeedbackRepository;
+import com.challang.backend.liquor.dto.response.LiquorResponse;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.liquor.repository.LiquorRepository;
+import com.challang.backend.preference.entity.LiquorPreferenceTag;
+import com.challang.backend.preference.repository.*;
+import com.challang.backend.review.repository.ReviewRepository;
+import com.challang.backend.tag.entity.LiquorTag;
+import com.challang.backend.tag.entity.Tag;
+import com.challang.backend.user.entity.User;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+
+    private final LiquorRepository liquorRepository;
+    private final LiquorPreferenceTypeRepository preferenceTypeRepository;
+    private final LiquorPreferenceLevelRepository preferenceLevelRepository;
+    private final LiquorPreferenceTagRepository preferenceTagRepository;
+
+    private final LiquorFeedbackRepository feedbackRepository;
+    private final ArchiveRepository archiveRepository;
+    private final ReviewRepository reviewRepository;
+
+
+    @Value("${cloud.aws.s3.url}")
+    private String s3BaseUrl;
+
+    public List<LiquorResponse> recommendLiquor(User user) {
+        // 1. 선호 정보 가져오기
+        // 주종
+        Set<Long> typeIds = preferenceTypeRepository.findByUser(user).stream()
+                .map((p) -> p.getLiquorType().getId()).collect(Collectors.toSet());
+
+        // 도수
+        Set<Long> levelIds = preferenceLevelRepository.findByUser(user).stream()
+                .map((p) -> p.getLiquorLevel().getId()).collect(Collectors.toSet());
+
+        // 태그
+        Set<Tag> preferredTags = preferenceTagRepository.findByUser(user).stream()
+                .map(LiquorPreferenceTag::getTag).collect(Collectors.toSet());
+
+        // 2. 필터링 (주종 + 도수)
+        List<Liquor> liquors = liquorRepository.findWithTagsByTypeAndLevel(typeIds, levelIds);
+
+        // 3. 피드백, 아카이브, 리뷰 제외
+        Set<Long> excludeIds = new HashSet<>();
+        feedbackRepository.findByUser(user).forEach(f -> {
+            excludeIds.add(f.getLiquor().getId());
+        });
+        archiveRepository.findByUser(user).forEach(a -> {
+            excludeIds.add(a.getLiquor().getId());
+        });
+        reviewRepository.findByWriter(user).forEach(r -> {
+            excludeIds.add(r.getLiquor().getId());
+        });
+
+        liquors = liquors.stream()
+                .filter(l -> !excludeIds.contains(l.getId()))
+                .toList();
+
+        // 4. 유사도 계산
+        List<LiquorScore> scores = liquors.stream()
+                .map(l -> new LiquorScore(l, calculateJaccard(preferredTags, l)))
+                .sorted(Comparator.comparingDouble(LiquorScore::similarity).reversed())
+                .limit(10)
+                .toList();
+
+        return scores.stream()
+                .map(s -> LiquorResponse.fromEntity(s.liquor, s3BaseUrl))
+                .toList();
+
+    }
+
+    private double calculateJaccard(Set<Tag> userTags, Liquor liquor) {
+        Set<Tag> liquorTags = liquor.getLiquorTags().stream()
+                .map(LiquorTag::getTag).collect(Collectors.toSet());
+
+        if (userTags.isEmpty() || liquorTags.isEmpty()) {
+            return 0.0;
+        }
+
+        Set<Tag> intersection = new HashSet<>(userTags);
+        intersection.retainAll(userTags);
+
+        Set<Tag> union = new HashSet<>(userTags);
+        union.addAll(liquorTags);
+
+        return (double) intersection.size() / union.size();
+    }
+
+
+    private record LiquorScore(Liquor liquor, double similarity) {
+    }
+
+}

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.challang.backend.review.repository;
 
 import com.challang.backend.review.entity.Review;
+import com.challang.backend.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
@@ -12,4 +13,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Modifying
     @Query("DELETE FROM Review r WHERE r.liquor.id = :liquorId")
     void deleteByLiquorId(@Param("liquorId") Long liquorId);
+
+    // 술 id만 얻는 용도 => joinX
+    List<Review> findByWriter(User user);
 }


### PR DESCRIPTION
## ✨ 주요 기능

- 사용자 선호 정보(주종, 도수, 태그)를 기반으로 술 추천
- 추천 대상은 아래 항목을 기준으로 필터링
  - 사용자가 이미 피드백(GOOD/BAD)을 남긴 술
  - 아카이브에 등록한 술
  - 리뷰를 작성한 술
- 필터링된 술에 대해 태그 유사도(Jaccard)를 계산하고, 상위 10개의 술을 추천 리스트로 제공한다.

## 🛠 변경 사항

- `RecommendController`, `RecommendService` 신규 생성
- 선호 정보 조회 및 추천 필터링 로직 구현
- `LiquorRepository`에 `findWithTagsByTypeAndLevel` 메서드 추가
- `LiquorPreference` 관련 Repository 메서드 구현
- `ReviewRepository`, `ArchiveRepository`에 유저 기반 조회 메서드 추가
- 추천 결과는 `LiquorResponse`를 그대로 활용하여 반환

## 🔧 성능 고려 사항

- 리뷰, 아카이브, 피드백 등에서 제외할 술 ID 조회 시에는 **join 없이 `liquor.id`만 조회하는 메서드를 사용**
- 이는 단순 ID 조회 목적이며, **불필요한 연관 관계 로딩을 방지하기 위함**이다.
  ```java
  // 술 id만 얻는 용도 => join X
  List<Review> findByWriter(User user);
  List<Archive> findByUser(User user);
  List<LiquorFeedback> findByUser(User user);

## 🔗 엔드포인트

- `GET /api/recommend`  
  → 로그인 사용자의 추천 리스트 조회



closes #37