### PR TITLE
[Refactor] 리뷰 기능 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -17,6 +17,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	queryDslVersion = "5.0.0"
+}
+
 dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -27,6 +31,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	compileOnly 'org.projectlombok:lombok'
+
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -41,6 +51,20 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation platform('software.amazon.awssdk:bom:2.20.56')
 	implementation 'software.amazon.awssdk:s3'
+}
+
+def generated = 'src/main/generated'
+
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+	delete file(generated)
 }
 
 tasks.named('test') {

--- a/backend/src/main/generated/com/challang/backend/archive/entity/QArchive.java
+++ b/backend/src/main/generated/com/challang/backend/archive/entity/QArchive.java
@@ -1,0 +1,62 @@
+package com.challang.backend.archive.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QArchive is a Querydsl query type for Archive
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QArchive extends EntityPathBase<Archive> {
+
+    private static final long serialVersionUID = 352246816L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QArchive archive = new QArchive("archive");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.challang.backend.liquor.entity.QLiquor liquor;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.challang.backend.user.entity.QUser user;
+
+    public QArchive(String variable) {
+        this(Archive.class, forVariable(variable), INITS);
+    }
+
+    public QArchive(Path<? extends Archive> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QArchive(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QArchive(PathMetadata metadata, PathInits inits) {
+        this(Archive.class, metadata, inits);
+    }
+
+    public QArchive(Class<? extends Archive> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.liquor = inits.isInitialized("liquor") ? new com.challang.backend.liquor.entity.QLiquor(forProperty("liquor"), inits.get("liquor")) : null;
+        this.user = inits.isInitialized("user") ? new com.challang.backend.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/feedback/entity/QLiquorFeedback.java
+++ b/backend/src/main/generated/com/challang/backend/feedback/entity/QLiquorFeedback.java
@@ -1,0 +1,64 @@
+package com.challang.backend.feedback.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLiquorFeedback is a Querydsl query type for LiquorFeedback
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquorFeedback extends EntityPathBase<LiquorFeedback> {
+
+    private static final long serialVersionUID = -573317016L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLiquorFeedback liquorFeedback = new QLiquorFeedback("liquorFeedback");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.challang.backend.liquor.entity.QLiquor liquor;
+
+    public final EnumPath<FeedbackType> type = createEnum("type", FeedbackType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.challang.backend.user.entity.QUser user;
+
+    public QLiquorFeedback(String variable) {
+        this(LiquorFeedback.class, forVariable(variable), INITS);
+    }
+
+    public QLiquorFeedback(Path<? extends LiquorFeedback> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLiquorFeedback(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLiquorFeedback(PathMetadata metadata, PathInits inits) {
+        this(LiquorFeedback.class, metadata, inits);
+    }
+
+    public QLiquorFeedback(Class<? extends LiquorFeedback> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.liquor = inits.isInitialized("liquor") ? new com.challang.backend.liquor.entity.QLiquor(forProperty("liquor"), inits.get("liquor")) : null;
+        this.user = inits.isInitialized("user") ? new com.challang.backend.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/liquor/entity/QLiquor.java
+++ b/backend/src/main/generated/com/challang/backend/liquor/entity/QLiquor.java
@@ -1,0 +1,82 @@
+package com.challang.backend.liquor.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLiquor is a Querydsl query type for Liquor
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquor extends EntityPathBase<Liquor> {
+
+    private static final long serialVersionUID = -1420833982L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLiquor liquor = new QLiquor("liquor");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    public final NumberPath<Double> averageRating = createNumber("averageRating", Double.class);
+
+    public final StringPath color = createString("color");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imageUrl = createString("imageUrl");
+
+    public final QLiquorLevel level;
+
+    public final ListPath<com.challang.backend.tag.entity.LiquorTag, com.challang.backend.tag.entity.QLiquorTag> liquorTags = this.<com.challang.backend.tag.entity.LiquorTag, com.challang.backend.tag.entity.QLiquorTag>createList("liquorTags", com.challang.backend.tag.entity.LiquorTag.class, com.challang.backend.tag.entity.QLiquorTag.class, PathInits.DIRECT2);
+
+    public final NumberPath<Double> maxAbv = createNumber("maxAbv", Double.class);
+
+    public final NumberPath<Double> minAbv = createNumber("minAbv", Double.class);
+
+    public final StringPath name = createString("name");
+
+    public final StringPath origin = createString("origin");
+
+    public final NumberPath<Integer> reviewCount = createNumber("reviewCount", Integer.class);
+
+    public final StringPath tastingNote = createString("tastingNote");
+
+    public final QLiquorType type;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QLiquor(String variable) {
+        this(Liquor.class, forVariable(variable), INITS);
+    }
+
+    public QLiquor(Path<? extends Liquor> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLiquor(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLiquor(PathMetadata metadata, PathInits inits) {
+        this(Liquor.class, metadata, inits);
+    }
+
+    public QLiquor(Class<? extends Liquor> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.level = inits.isInitialized("level") ? new QLiquorLevel(forProperty("level")) : null;
+        this.type = inits.isInitialized("type") ? new QLiquorType(forProperty("type")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/liquor/entity/QLiquorLevel.java
+++ b/backend/src/main/generated/com/challang/backend/liquor/entity/QLiquorLevel.java
@@ -1,0 +1,47 @@
+package com.challang.backend.liquor.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QLiquorLevel is a Querydsl query type for LiquorLevel
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquorLevel extends EntityPathBase<LiquorLevel> {
+
+    private static final long serialVersionUID = -355100318L;
+
+    public static final QLiquorLevel liquorLevel = new QLiquorLevel("liquorLevel");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QLiquorLevel(String variable) {
+        super(LiquorLevel.class, forVariable(variable));
+    }
+
+    public QLiquorLevel(Path<? extends LiquorLevel> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QLiquorLevel(PathMetadata metadata) {
+        super(LiquorLevel.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/liquor/entity/QLiquorType.java
+++ b/backend/src/main/generated/com/challang/backend/liquor/entity/QLiquorType.java
@@ -1,0 +1,47 @@
+package com.challang.backend.liquor.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QLiquorType is a Querydsl query type for LiquorType
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquorType extends EntityPathBase<LiquorType> {
+
+    private static final long serialVersionUID = -1673765476L;
+
+    public static final QLiquorType liquorType = new QLiquorType("liquorType");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QLiquorType(String variable) {
+        super(LiquorType.class, forVariable(variable));
+    }
+
+    public QLiquorType(Path<? extends LiquorType> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QLiquorType(PathMetadata metadata) {
+        super(LiquorType.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/preference/entity/QLiquorPreferenceLevel.java
+++ b/backend/src/main/generated/com/challang/backend/preference/entity/QLiquorPreferenceLevel.java
@@ -1,0 +1,62 @@
+package com.challang.backend.preference.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLiquorPreferenceLevel is a Querydsl query type for LiquorPreferenceLevel
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquorPreferenceLevel extends EntityPathBase<LiquorPreferenceLevel> {
+
+    private static final long serialVersionUID = 1698756304L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLiquorPreferenceLevel liquorPreferenceLevel = new QLiquorPreferenceLevel("liquorPreferenceLevel");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.challang.backend.liquor.entity.QLiquorLevel liquorLevel;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.challang.backend.user.entity.QUser user;
+
+    public QLiquorPreferenceLevel(String variable) {
+        this(LiquorPreferenceLevel.class, forVariable(variable), INITS);
+    }
+
+    public QLiquorPreferenceLevel(Path<? extends LiquorPreferenceLevel> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLiquorPreferenceLevel(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLiquorPreferenceLevel(PathMetadata metadata, PathInits inits) {
+        this(LiquorPreferenceLevel.class, metadata, inits);
+    }
+
+    public QLiquorPreferenceLevel(Class<? extends LiquorPreferenceLevel> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.liquorLevel = inits.isInitialized("liquorLevel") ? new com.challang.backend.liquor.entity.QLiquorLevel(forProperty("liquorLevel")) : null;
+        this.user = inits.isInitialized("user") ? new com.challang.backend.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/preference/entity/QLiquorPreferenceTag.java
+++ b/backend/src/main/generated/com/challang/backend/preference/entity/QLiquorPreferenceTag.java
@@ -1,0 +1,62 @@
+package com.challang.backend.preference.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLiquorPreferenceTag is a Querydsl query type for LiquorPreferenceTag
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquorPreferenceTag extends EntityPathBase<LiquorPreferenceTag> {
+
+    private static final long serialVersionUID = 1838644710L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLiquorPreferenceTag liquorPreferenceTag = new QLiquorPreferenceTag("liquorPreferenceTag");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.challang.backend.tag.entity.QTag tag;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.challang.backend.user.entity.QUser user;
+
+    public QLiquorPreferenceTag(String variable) {
+        this(LiquorPreferenceTag.class, forVariable(variable), INITS);
+    }
+
+    public QLiquorPreferenceTag(Path<? extends LiquorPreferenceTag> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLiquorPreferenceTag(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLiquorPreferenceTag(PathMetadata metadata, PathInits inits) {
+        this(LiquorPreferenceTag.class, metadata, inits);
+    }
+
+    public QLiquorPreferenceTag(Class<? extends LiquorPreferenceTag> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.tag = inits.isInitialized("tag") ? new com.challang.backend.tag.entity.QTag(forProperty("tag")) : null;
+        this.user = inits.isInitialized("user") ? new com.challang.backend.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/preference/entity/QLiquorPreferenceType.java
+++ b/backend/src/main/generated/com/challang/backend/preference/entity/QLiquorPreferenceType.java
@@ -1,0 +1,62 @@
+package com.challang.backend.preference.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLiquorPreferenceType is a Querydsl query type for LiquorPreferenceType
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquorPreferenceType extends EntityPathBase<LiquorPreferenceType> {
+
+    private static final long serialVersionUID = 1163434606L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLiquorPreferenceType liquorPreferenceType = new QLiquorPreferenceType("liquorPreferenceType");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.challang.backend.liquor.entity.QLiquorType liquorType;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.challang.backend.user.entity.QUser user;
+
+    public QLiquorPreferenceType(String variable) {
+        this(LiquorPreferenceType.class, forVariable(variable), INITS);
+    }
+
+    public QLiquorPreferenceType(Path<? extends LiquorPreferenceType> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLiquorPreferenceType(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLiquorPreferenceType(PathMetadata metadata, PathInits inits) {
+        this(LiquorPreferenceType.class, metadata, inits);
+    }
+
+    public QLiquorPreferenceType(Class<? extends LiquorPreferenceType> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.liquorType = inits.isInitialized("liquorType") ? new com.challang.backend.liquor.entity.QLiquorType(forProperty("liquorType")) : null;
+        this.user = inits.isInitialized("user") ? new com.challang.backend.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/review/entity/QReview.java
+++ b/backend/src/main/generated/com/challang/backend/review/entity/QReview.java
@@ -1,0 +1,74 @@
+package com.challang.backend.review.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QReview is a Querydsl query type for Review
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReview extends EntityPathBase<Review> {
+
+    private static final long serialVersionUID = -319716630L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QReview review = new QReview("review");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Integer> dislikeCount = createNumber("dislikeCount", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imageUrl = createString("imageUrl");
+
+    public final NumberPath<Integer> likeCount = createNumber("likeCount", Integer.class);
+
+    public final com.challang.backend.liquor.entity.QLiquor liquor;
+
+    public final NumberPath<Double> rating = createNumber("rating", Double.class);
+
+    public final ListPath<ReviewTag, QReviewTag> reviewTags = this.<ReviewTag, QReviewTag>createList("reviewTags", ReviewTag.class, QReviewTag.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.challang.backend.user.entity.QUser writer;
+
+    public QReview(String variable) {
+        this(Review.class, forVariable(variable), INITS);
+    }
+
+    public QReview(Path<? extends Review> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QReview(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QReview(PathMetadata metadata, PathInits inits) {
+        this(Review.class, metadata, inits);
+    }
+
+    public QReview(Class<? extends Review> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.liquor = inits.isInitialized("liquor") ? new com.challang.backend.liquor.entity.QLiquor(forProperty("liquor"), inits.get("liquor")) : null;
+        this.writer = inits.isInitialized("writer") ? new com.challang.backend.user.entity.QUser(forProperty("writer")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/review/entity/QReviewReaction.java
+++ b/backend/src/main/generated/com/challang/backend/review/entity/QReviewReaction.java
@@ -1,0 +1,56 @@
+package com.challang.backend.review.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QReviewReaction is a Querydsl query type for ReviewReaction
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReviewReaction extends EntityPathBase<ReviewReaction> {
+
+    private static final long serialVersionUID = -2097006797L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QReviewReaction reviewReaction = new QReviewReaction("reviewReaction");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QReview review;
+
+    public final EnumPath<ReactionType> type = createEnum("type", ReactionType.class);
+
+    public final com.challang.backend.user.entity.QUser user;
+
+    public QReviewReaction(String variable) {
+        this(ReviewReaction.class, forVariable(variable), INITS);
+    }
+
+    public QReviewReaction(Path<? extends ReviewReaction> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QReviewReaction(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QReviewReaction(PathMetadata metadata, PathInits inits) {
+        this(ReviewReaction.class, metadata, inits);
+    }
+
+    public QReviewReaction(Class<? extends ReviewReaction> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.review = inits.isInitialized("review") ? new QReview(forProperty("review"), inits.get("review")) : null;
+        this.user = inits.isInitialized("user") ? new com.challang.backend.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/review/entity/QReviewTag.java
+++ b/backend/src/main/generated/com/challang/backend/review/entity/QReviewTag.java
@@ -1,0 +1,54 @@
+package com.challang.backend.review.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QReviewTag is a Querydsl query type for ReviewTag
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReviewTag extends EntityPathBase<ReviewTag> {
+
+    private static final long serialVersionUID = 1559422032L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QReviewTag reviewTag = new QReviewTag("reviewTag");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QReview review;
+
+    public final com.challang.backend.tag.entity.QTag tag;
+
+    public QReviewTag(String variable) {
+        this(ReviewTag.class, forVariable(variable), INITS);
+    }
+
+    public QReviewTag(Path<? extends ReviewTag> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QReviewTag(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QReviewTag(PathMetadata metadata, PathInits inits) {
+        this(ReviewTag.class, metadata, inits);
+    }
+
+    public QReviewTag(Class<? extends ReviewTag> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.review = inits.isInitialized("review") ? new QReview(forProperty("review"), inits.get("review")) : null;
+        this.tag = inits.isInitialized("tag") ? new com.challang.backend.tag.entity.QTag(forProperty("tag")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/tag/entity/QLiquorTag.java
+++ b/backend/src/main/generated/com/challang/backend/tag/entity/QLiquorTag.java
@@ -1,0 +1,64 @@
+package com.challang.backend.tag.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLiquorTag is a Querydsl query type for LiquorTag
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLiquorTag extends EntityPathBase<LiquorTag> {
+
+    private static final long serialVersionUID = -213267076L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLiquorTag liquorTag = new QLiquorTag("liquorTag");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isCore = createBoolean("isCore");
+
+    public final com.challang.backend.liquor.entity.QLiquor liquor;
+
+    public final QTag tag;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QLiquorTag(String variable) {
+        this(LiquorTag.class, forVariable(variable), INITS);
+    }
+
+    public QLiquorTag(Path<? extends LiquorTag> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLiquorTag(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLiquorTag(PathMetadata metadata, PathInits inits) {
+        this(LiquorTag.class, metadata, inits);
+    }
+
+    public QLiquorTag(Class<? extends LiquorTag> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.liquor = inits.isInitialized("liquor") ? new com.challang.backend.liquor.entity.QLiquor(forProperty("liquor"), inits.get("liquor")) : null;
+        this.tag = inits.isInitialized("tag") ? new QTag(forProperty("tag")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/tag/entity/QTag.java
+++ b/backend/src/main/generated/com/challang/backend/tag/entity/QTag.java
@@ -1,0 +1,47 @@
+package com.challang.backend.tag.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTag is a Querydsl query type for Tag
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTag extends EntityPathBase<Tag> {
+
+    private static final long serialVersionUID = -658785632L;
+
+    public static final QTag tag = new QTag("tag");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QTag(String variable) {
+        super(Tag.class, forVariable(variable));
+    }
+
+    public QTag(Path<? extends Tag> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTag(PathMetadata metadata) {
+        super(Tag.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/user/entity/QUser.java
+++ b/backend/src/main/generated/com/challang/backend/user/entity/QUser.java
@@ -1,0 +1,61 @@
+package com.challang.backend.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 595527440L;
+
+    public static final QUser user = new QUser("user");
+
+    public final com.challang.backend.util.entity.QBaseEntity _super = new com.challang.backend.util.entity.QBaseEntity(this);
+
+    public final EnumPath<AuthType> authType = createEnum("authType", AuthType.class);
+
+    public final DatePath<java.time.LocalDate> birthDate = createDate("birthDate", java.time.LocalDate.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Integer> gender = createNumber("gender", Integer.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath oauthId = createString("oauthId");
+
+    public final StringPath password = createString("password");
+
+    public final EnumPath<UserRole> role = createEnum("role", UserRole.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/challang/backend/util/entity/QBaseEntity.java
+++ b/backend/src/main/generated/com/challang/backend/util/entity/QBaseEntity.java
@@ -1,0 +1,39 @@
+package com.challang.backend.util.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = -1480421872L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/java/com/challang/backend/config/QueryDslConfig.java
+++ b/backend/src/main/java/com/challang/backend/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.challang.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/LiquorResponse.java
@@ -18,9 +18,11 @@ public record LiquorResponse(
         String levelName,
         Long typeId,
         String typeName,
-        List<LiquorTagResponse> liquorTags
+        List<LiquorTagResponse> liquorTags,
+        double averageRating,
+        List<TagStatDto> topTagStats
 ) {
-    public static LiquorResponse fromEntity(Liquor liquor, String s3BaseUrl) {
+    public static LiquorResponse fromEntity(Liquor liquor, String s3BaseUrl, List<TagStatDto> topTagStats) {
         List<LiquorTagResponse> liquorTags = liquor.getLiquorTags().stream()
                 .map(LiquorTagResponse::fromEntity)
                 .toList();
@@ -40,8 +42,13 @@ public record LiquorResponse(
                 liquor.getLevel().getName(),
                 liquor.getType().getId(),
                 liquor.getType().getName(),
-                liquorTags
+                liquorTags,
+                liquor.getAverageRating(),
+                topTagStats
         );
     }
 
+    public static LiquorResponse fromEntity(Liquor liquor, String s3BaseUrl) {
+        return fromEntity(liquor, s3BaseUrl, List.of()); // topTagStats를 빈 리스트로 넘겨 호출
+    }
 }

--- a/backend/src/main/java/com/challang/backend/liquor/dto/response/TagStatDto.java
+++ b/backend/src/main/java/com/challang/backend/liquor/dto/response/TagStatDto.java
@@ -1,0 +1,3 @@
+package com.challang.backend.liquor.dto.response;
+
+public record TagStatDto(String tagName, double percentage) {}

--- a/backend/src/main/java/com/challang/backend/liquor/entity/Liquor.java
+++ b/backend/src/main/java/com/challang/backend/liquor/entity/Liquor.java
@@ -6,6 +6,7 @@ import com.challang.backend.util.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.util.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Table(name = "liquor")
@@ -49,6 +50,18 @@ public class Liquor extends BaseEntity {
     @OneToMany(mappedBy = "liquor")
     private final List<LiquorTag> liquorTags = new ArrayList<>();
 
+    @Column(name = "average_rating")
+    @ColumnDefault("0.0")
+    private Double averageRating;
+
+    @Column(name = "review_count")
+    @ColumnDefault("0")
+    private Integer reviewCount;
+
+    public void updateAverageRating(Double newAverageRating, Integer newReviewCount) {
+        this.averageRating = newAverageRating;
+        this.reviewCount = newReviewCount;
+    }
 
     @Builder
     public Liquor(LiquorLevel level, LiquorType type, String name, String imageUrl, String tastingNote, String origin,

--- a/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
@@ -6,7 +6,7 @@ import com.challang.backend.review.dto.request.ReviewUpdateRequestDto;
 import com.challang.backend.review.dto.response.ReviewResponseDto;
 import com.challang.backend.review.service.ReviewService;
 import com.challang.backend.user.entity.User;
-import com.challang.backend.util.response.BaseResponse; // BaseResponse import
+import com.challang.backend.util.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,6 +19,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.challang.backend.review.dto.request.ReportRequestDto;
+import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Pageable;
 import java.util.List;
@@ -56,9 +58,9 @@ public class ReviewController {
     public ResponseEntity<BaseResponse<Page<ReviewResponseDto>>> getReviews(
             @Parameter(description = "주류 ID") @PathVariable Long liquorId,
             @Parameter(description = "필터링할 태그 ID 목록") @RequestParam(required = false) List<Long> tagIds,
-            @Parameter(hidden = true)
+            @Parameter(description = "정렬 조건 (예: 'createdAt,desc' 또는 'likeCount,desc')")
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        // 서비스 메서드가 Page 객체를 반환하도록 변경
+
         Page<ReviewResponseDto> responsePage = reviewService.getReviewsByLiquor(liquorId, tagIds, pageable);
         return ResponseEntity.ok(new BaseResponse<>(responsePage));
     }
@@ -137,8 +139,10 @@ public class ReviewController {
     @PostMapping("/reviews/{reviewId}/report")
     public ResponseEntity<BaseResponse<String>> reportReview(
             @PathVariable Long reviewId,
+            @Valid @RequestBody ReportRequestDto request,
             @CurrentUser User user) {
-        reviewService.reportReview(reviewId, user);
+
+        reviewService.reportReview(reviewId, request, user);
         return ResponseEntity.ok(new BaseResponse<>("신고가 접수되었습니다."));
     }
 }

--- a/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/challang/backend/review/controller/ReviewController.java
@@ -1,7 +1,6 @@
 package com.challang.backend.review.controller;
 
 import com.challang.backend.auth.annotation.CurrentUser;
-import com.challang.backend.auth.jwt.CustomUserDetails;
 import com.challang.backend.review.dto.request.ReviewCreateRequestDto;
 import com.challang.backend.review.dto.request.ReviewUpdateRequestDto;
 import com.challang.backend.review.dto.response.ReviewResponseDto;
@@ -15,10 +14,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 @Tag(name = "Review", description = "리뷰 관련 API")
@@ -45,14 +47,20 @@ public class ReviewController {
         return ResponseEntity.ok(new BaseResponse<>(responseDto));
     }
 
-    @Operation(summary = "특정 주류의 리뷰 목록 조회", description = "주류 ID로 해당 주류의 모든 리뷰를 조회합니다.")
+    @Operation(summary = "특정 주류의 리뷰 목록 조회", description = "태그로 필터링하거나, 최신순/추천순으로 정렬하여 리뷰 목록을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "주류 정보를 찾을 수 없음")
     })
     @GetMapping("/liquors/{liquorId}/reviews")
-    public ResponseEntity<BaseResponse<List<ReviewResponseDto>>> getReviews(@PathVariable Long liquorId) {
-        List<ReviewResponseDto> responseDtoList = reviewService.getReviews(liquorId);
-        return ResponseEntity.ok(new BaseResponse<>(responseDtoList));
+    public ResponseEntity<BaseResponse<Page<ReviewResponseDto>>> getReviews(
+            @Parameter(description = "주류 ID") @PathVariable Long liquorId,
+            @Parameter(description = "필터링할 태그 ID 목록") @RequestParam(required = false) List<Long> tagIds,
+            @Parameter(hidden = true)
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        // 서비스 메서드가 Page 객체를 반환하도록 변경
+        Page<ReviewResponseDto> responsePage = reviewService.getReviewsByLiquor(liquorId, tagIds, pageable);
+        return ResponseEntity.ok(new BaseResponse<>(responsePage));
     }
 
     @Operation(summary = "리뷰 수정", description = "자신이 작성한 리뷰를 수정합니다. (인증 필요)")
@@ -68,7 +76,7 @@ public class ReviewController {
             @PathVariable Long reviewId,
             @RequestBody ReviewUpdateRequestDto request,
             @CurrentUser User user) {
-        ReviewResponseDto responseDto = reviewService.updateReview(reviewId, request, user.getUserId());
+        ReviewResponseDto responseDto = reviewService.updateReview(reviewId, request, user);
         return ResponseEntity.ok(new BaseResponse<>(responseDto));
     }
 
@@ -84,7 +92,53 @@ public class ReviewController {
     public ResponseEntity<BaseResponse<String>> deleteReview(
             @PathVariable Long reviewId,
             @CurrentUser User user) {
-        reviewService.deleteReview(reviewId, user.getUserId());
+        reviewService.deleteReview(reviewId, user);
         return ResponseEntity.ok(new BaseResponse<>("리뷰가 성공적으로 삭제되었습니다."));
+    }
+
+    @Operation(summary = "리뷰 추천/추천 취소", description = "리뷰를 추천하거나 추천을 취소합니다. (인증 필요)")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "리뷰 또는 사용자 정보를 찾을 수 없음")
+    })
+    @PostMapping("/reviews/{reviewId}/like")
+    public ResponseEntity<BaseResponse<String>> likeReview(
+            @PathVariable Long reviewId,
+            @CurrentUser User user) {
+        reviewService.likeReview(reviewId, user);
+        return ResponseEntity.ok(new BaseResponse<>("요청이 처리되었습니다."));
+    }
+
+    @Operation(summary = "리뷰 비추천/비추천 취소", description = "리뷰를 비추천하거나 비추천을 취소합니다. (인증 필요)")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "리뷰 또는 사용자 정보를 찾을 수 없음")
+    })
+    @PostMapping("/reviews/{reviewId}/dislike")
+    public ResponseEntity<BaseResponse<String>> dislikeReview(
+            @PathVariable Long reviewId,
+            @CurrentUser User user) {
+        reviewService.dislikeReview(reviewId, user);
+        return ResponseEntity.ok(new BaseResponse<>("요청이 처리되었습니다."));
+    }
+
+    @Operation(summary = "리뷰 신고", description = "리뷰를 신고합니다. (인증 필요)")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "신고 접수 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "리뷰 또는 사용자 정보를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 신고한 리뷰")
+    })
+    @PostMapping("/reviews/{reviewId}/report")
+    public ResponseEntity<BaseResponse<String>> reportReview(
+            @PathVariable Long reviewId,
+            @CurrentUser User user) {
+        reviewService.reportReview(reviewId, user);
+        return ResponseEntity.ok(new BaseResponse<>("신고가 접수되었습니다."));
     }
 }

--- a/backend/src/main/java/com/challang/backend/review/dto/request/ReportRequestDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/request/ReportRequestDto.java
@@ -1,0 +1,10 @@
+package com.challang.backend.review.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+// record를 사용하면 간결하게 DTO를 정의할 수 있습니다.
+public record ReportRequestDto(
+        @NotBlank(message = "신고 사유는 필수 입력값입니다.")
+        String reason
+) {
+}

--- a/backend/src/main/java/com/challang/backend/review/dto/request/ReviewCreateRequestDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/request/ReviewCreateRequestDto.java
@@ -1,12 +1,18 @@
 package com.challang.backend.review.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.*;
+
+import java.util.List;
 
 public record ReviewCreateRequestDto(
         @NotBlank(message = "리뷰 내용은 필수 입력값입니다.")
         String content,
 
         @NotBlank(message = "리뷰 이미지는 필수입니다.")
-        String imageUrl
+        String imageUrl,
+
+        @NotNull @Min(1) @Max(5) int rating,
+
+        @NotNull @Size(max = 3, message = "해시태그는 최대 3개까지 선택 가능합니다.") List<Long> tagIds
 ) {
 }

--- a/backend/src/main/java/com/challang/backend/review/dto/request/ReviewUpdateRequestDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/request/ReviewUpdateRequestDto.java
@@ -1,7 +1,11 @@
 package com.challang.backend.review.dto.request;
 
+import java.util.List;
+
 public record ReviewUpdateRequestDto(
         String content,
-        String imageUrl
+        String imageUrl,
+        Double rating,
+        List<Long> tagIds
 ) {
 }

--- a/backend/src/main/java/com/challang/backend/review/dto/response/ReviewResponseDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/response/ReviewResponseDto.java
@@ -32,8 +32,8 @@ public record ReviewResponseDto(
                 fullImageUrl,
                 review.getCreatedAt(),
                 review.getRating(),
-                review.getLikeCount(),
-                review.getDislikeCount(),
+                review.getLikeCount() != null ? review.getLikeCount() : 0,
+                review.getDislikeCount() != null ? review.getDislikeCount() : 0,
                 tagNames
         );
     }

--- a/backend/src/main/java/com/challang/backend/review/dto/response/ReviewResponseDto.java
+++ b/backend/src/main/java/com/challang/backend/review/dto/response/ReviewResponseDto.java
@@ -2,6 +2,8 @@ package com.challang.backend.review.dto.response;
 
 import com.challang.backend.review.entity.Review;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public record ReviewResponseDto(
         Long reviewId,
@@ -9,17 +11,30 @@ public record ReviewResponseDto(
         String writerNickname,
         String content,
         String imageUrl,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        Double rating,
+        int likeCount,
+        int dislikeCount,
+        List<String> hashtags
 ) {
     public static ReviewResponseDto from(Review review, String s3BaseUrl) {
         String fullImageUrl = s3BaseUrl + "/" + review.getImageUrl();
+
+        List<String> tagNames = review.getReviewTags().stream()
+                .map(reviewTag -> reviewTag.getTag().getName())
+                .collect(Collectors.toList());
+
         return new ReviewResponseDto(
                 review.getId(),
                 review.getWriter().getUserId(),
                 review.getWriter().getNickname(),
                 review.getContent(),
                 fullImageUrl,
-                review.getCreatedAt()
+                review.getCreatedAt(),
+                review.getRating(),
+                review.getLikeCount(),
+                review.getDislikeCount(),
+                tagNames
         );
     }
 }

--- a/backend/src/main/java/com/challang/backend/review/entity/ReactionType.java
+++ b/backend/src/main/java/com/challang/backend/review/entity/ReactionType.java
@@ -1,0 +1,5 @@
+package com.challang.backend.review.entity;
+
+public enum ReactionType {
+    LIKE, DISLIKE
+}

--- a/backend/src/main/java/com/challang/backend/review/entity/Review.java
+++ b/backend/src/main/java/com/challang/backend/review/entity/Review.java
@@ -7,6 +7,9 @@ import com.challang.backend.util.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "review")
 @Getter
@@ -33,14 +36,51 @@ public class Review extends BaseEntity {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
-    public void update(ReviewUpdateRequestDto request) {
+    @Column(name = "rating", nullable = false)
+    private Double rating;
+
+    @Builder.Default
+    @Column(name = "like_count")
+    private int likeCount = 0;
+
+    @Builder.Default
+    @Column(name = "dislike_count")
+    private int dislikeCount = 0;
+
+    // 리뷰에 선택된 해시태그 목록
+    @Builder.Default
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewTag> reviewTags = new ArrayList<>();
+
+    public void update(ReviewUpdateRequestDto request, List<ReviewTag> newTags) {
         if (request.content() != null) {
             this.content = request.content();
         }
         if (request.imageUrl() != null) {
             this.imageUrl = request.imageUrl();
         }
+        this.rating = request.rating();
+
+        this.reviewTags.clear();
+        this.reviewTags.addAll(newTags);
     }
 
+    public void increaseReactionCount(ReactionType reactionType) {
+        if (reactionType == ReactionType.LIKE) this.likeCount++;
+        else this.dislikeCount++;
+    }
 
+    public void decreaseReactionCount(ReactionType reactionType) {
+        if (reactionType == ReactionType.LIKE) this.likeCount--;
+        else this.dislikeCount--;
+    }
+
+    public void changeReaction(ReactionType from, ReactionType to) {
+        decreaseReactionCount(from);
+        increaseReactionCount(to);
+    }
+
+    public void addTags(List<ReviewTag> reviewTags) {
+        this.reviewTags.addAll(reviewTags);
+    }
 }

--- a/backend/src/main/java/com/challang/backend/review/entity/Review.java
+++ b/backend/src/main/java/com/challang/backend/review/entity/Review.java
@@ -39,16 +39,15 @@ public class Review extends BaseEntity {
     @Column(name = "rating", nullable = false)
     private Double rating;
 
-    @Builder.Default
     @Column(name = "like_count")
-    private int likeCount = 0;
+    private Integer likeCount = 0;
 
-    @Builder.Default
     @Column(name = "dislike_count")
-    private int dislikeCount = 0;
+    private Integer dislikeCount = 0;
 
-    // 리뷰에 선택된 해시태그 목록
-    @Builder.Default
+    @Column(name = "report_count")
+    private Integer reportCount = 0;
+
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewTag> reviewTags = new ArrayList<>();
 
@@ -73,6 +72,10 @@ public class Review extends BaseEntity {
     public void decreaseReactionCount(ReactionType reactionType) {
         if (reactionType == ReactionType.LIKE) this.likeCount--;
         else this.dislikeCount--;
+    }
+
+    public void increaseReportCount() {
+        this.reportCount++;
     }
 
     public void changeReaction(ReactionType from, ReactionType to) {

--- a/backend/src/main/java/com/challang/backend/review/entity/ReviewReaction.java
+++ b/backend/src/main/java/com/challang/backend/review/entity/ReviewReaction.java
@@ -1,0 +1,45 @@
+package com.challang.backend.review.entity;
+
+import com.challang.backend.review.entity.Review;
+import com.challang.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "review_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewReaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReactionType type; // LIKE, DISLIKE
+
+    public void updateType(ReactionType type) {
+        this.type = type;
+    }
+
+    @Builder
+    public ReviewReaction(User user, Review review, ReactionType type) {
+        this.user = user;
+        this.review = review;
+        this.type = type;
+    }
+}
+

--- a/backend/src/main/java/com/challang/backend/review/entity/ReviewTag.java
+++ b/backend/src/main/java/com/challang/backend/review/entity/ReviewTag.java
@@ -1,0 +1,34 @@
+package com.challang.backend.review.entity;
+
+import com.challang.backend.tag.entity.Tag;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewTag {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag; // 기존 Tag 엔티티
+
+    @Builder
+    public ReviewTag(Review review, Tag tag) {
+        this.review = review;
+        this.tag = tag;
+    }
+}

--- a/backend/src/main/java/com/challang/backend/review/exception/ReviewErrorCode.java
+++ b/backend/src/main/java/com/challang/backend/review/exception/ReviewErrorCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.*;
 public enum ReviewErrorCode implements ResponseStatus {
 
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "해당 리뷰를 찾을 수 없습니다."),
-    NO_AUTHORITY_FOR_REVIEW(HttpStatus.FORBIDDEN, false, 403, "해당 리뷰에 대한 수정/삭제 권한이 없습니다.");
+    NO_AUTHORITY_FOR_REVIEW(HttpStatus.FORBIDDEN, false, 403, "해당 리뷰에 대한 수정/삭제 권한이 없습니다."),
+
+    INVALID_TAGS_FOR_LIQUOR(HttpStatus.BAD_REQUEST, false, 400, "해당 주류에 속하지 않은 태그가 포함되어 있습니다."),
+    ALREADY_REACTED(HttpStatus.CONFLICT, false, 409, "이미 해당 리뷰에 추천 또는 비추천을 하셨습니다."),
+    ALREADY_REPORTED(HttpStatus.CONFLICT, false, 409, "이미 신고한 리뷰입니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/backend/src/main/java/com/challang/backend/review/exception/ReviewErrorCode.java
+++ b/backend/src/main/java/com/challang/backend/review/exception/ReviewErrorCode.java
@@ -13,7 +13,8 @@ public enum ReviewErrorCode implements ResponseStatus {
 
     INVALID_TAGS_FOR_LIQUOR(HttpStatus.BAD_REQUEST, false, 400, "해당 주류에 속하지 않은 태그가 포함되어 있습니다."),
     ALREADY_REACTED(HttpStatus.CONFLICT, false, 409, "이미 해당 리뷰에 추천 또는 비추천을 하셨습니다."),
-    ALREADY_REPORTED(HttpStatus.CONFLICT, false, 409, "이미 신고한 리뷰입니다.");
+    ALREADY_REPORTED(HttpStatus.CONFLICT, false, 409, "이미 신고한 리뷰입니다."),
+    MAX_TAGS_EXCEEDED(HttpStatus.BAD_REQUEST, false, 400, "해시태그는 최대 3개까지 선택 가능합니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;

--- a/backend/src/main/java/com/challang/backend/review/exception/ReviewException.java
+++ b/backend/src/main/java/com/challang/backend/review/exception/ReviewException.java
@@ -1,0 +1,9 @@
+package com.challang.backend.review.exception;
+
+import com.challang.backend.global.exception.BaseException;
+
+public class ReviewException extends BaseException {
+    public ReviewException(ReviewErrorCode reviewErrorCode) {
+        super(reviewErrorCode);
+    }
+}

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewReactionRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewReactionRepository.java
@@ -1,0 +1,32 @@
+package com.challang.backend.review.repository;
+
+import com.challang.backend.review.entity.Review;
+import com.challang.backend.review.entity.ReviewReaction;
+import com.challang.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReviewReactionRepository extends JpaRepository<ReviewReaction, Long> {
+
+    /**
+     * 특정 사용자가 특정 리뷰에 대해 남긴 반응을 조회합니다.
+     * 사용자가 이미 추천/비추천을 했는지 확인하기 위해 사용됩니다.
+     *
+     * @param user   사용자 엔티티
+     * @param review 리뷰
+     * @return Optional<ReviewReaction> 객체 (존재하지 않을 수 있음)
+     */
+    Optional<ReviewReaction> findByUserAndReview(User user, Review review);
+
+    /**
+     * 특정 사용자가 특정 리뷰에 대해 남긴 반응을 삭제합니다.
+     * 추천/비추천을 취소(토글)할 때 사용됩니다.
+     *
+     * @param user   사용자 엔티티
+     * @param reviewId 리뷰의 ID
+     */
+    void deleteByUserAndReviewId(User user, Long reviewId);
+}

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
@@ -4,15 +4,23 @@ import com.challang.backend.review.entity.Review;
 import com.challang.backend.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 import java.util.List;
 import org.springframework.data.jpa.repository.*;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
     List<Review> findByLiquorIdOrderByIdDesc(Long liquorId);
+
+    int countByLiquorId(Long liquorId);
 
     @Modifying
     @Query("DELETE FROM Review r WHERE r.liquor.id = :liquorId")
     void deleteByLiquorId(@Param("liquorId") Long liquorId);
+
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.liquor.id = :liquorId")
+    Optional<Double> calculateAverageRatingByLiquorId(@Param("liquorId") Long liquorId);
 
     // 술 id만 얻는 용도 => joinX
     List<Review> findByWriter(User user);

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewRepositoryCustom.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.challang.backend.review.repository;
+
+import com.challang.backend.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface ReviewRepositoryCustom {
+    Page<Review> findReviewsByLiquorAndTags(Long liquorId, List<Long> tagIds, Pageable pageable);
+}

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewRepositoryImpl.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.challang.backend.review.repository;
+
+import com.challang.backend.review.entity.QReview;
+import com.challang.backend.review.entity.QReviewTag;
+import com.challang.backend.review.entity.Review;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable; // ❗ AWT가 아닌 Spring의 Pageable로 수정
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom { // ❗ 파일명을 ReviewRepositoryImpl.java로 유지
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Review> findReviewsByLiquorAndTags(Long liquorId, List<Long> tagIds, Pageable pageable) {
+        QReview review = QReview.review;
+
+        // 데이터 조회 쿼리
+        List<Review> content = queryFactory
+                .selectFrom(review)
+                .where(
+                        liquorIdEq(liquorId),
+                        tagsIn(tagIds)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifiers(pageable, review))
+                .fetch();
+
+        // Count 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(review.count())
+                .from(review)
+                .where(
+                        liquorIdEq(liquorId),
+                        tagsIn(tagIds)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    // BooleanBuilder 대신 BooleanExpression 사용을 권장 (재사용성, Null-safe)
+    private BooleanExpression liquorIdEq(Long liquorId) {
+        return QReview.review.liquor.id.eq(liquorId);
+    }
+
+    private BooleanExpression tagsIn(List<Long> tagIds) {
+        if (tagIds == null || tagIds.isEmpty()) {
+            return null;
+        }
+        return QReview.review.reviewTags.any().tag.id.in(tagIds);
+    }
+
+    // Pageable의 Sort 객체를 사용하여 동적 정렬 처리
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable, QReview review) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+                    String property = order.getProperty();
+                    PathBuilder<Review> pathBuilder = new PathBuilder<>(review.getType(), review.getMetadata());
+                    return new OrderSpecifier(direction, pathBuilder.get(property));
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+}

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewRepositoryImpl.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.challang.backend.review.repository;
 
 import com.challang.backend.review.entity.QReview;
-import com.challang.backend.review.entity.QReviewTag;
 import com.challang.backend.review.entity.Review;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -12,7 +11,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable; // ❗ AWT가 아닌 Spring의 Pageable로 수정
-import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
@@ -20,7 +18,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class ReviewRepositoryImpl implements ReviewRepositoryCustom { // ❗ 파일명을 ReviewRepositoryImpl.java로 유지
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewTagRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewTagRepository.java
@@ -1,44 +1,28 @@
 package com.challang.backend.review.repository;
 
-import com.challang.backend.liquor.dto.response.TagStatDto; // TagStatDto import
+import com.challang.backend.liquor.dto.response.TagStatDto;
 import com.challang.backend.review.entity.Review;
 import com.challang.backend.review.entity.ReviewTag;
-import org.springframework.data.domain.Pageable; // Pageable import
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 
 import java.util.List;
 
 public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
 
-    /**
-     * 특정 주류에 대한 태그 통계를 계산하고, 가장 많이 선택된 순으로 3개까지 조회합니다.
-     * @param liquorId 주류 ID
-     * @param pageable 결과를 3개로 제한하기 위한 Pageable 객체 (e.g., PageRequest.of(0, 3))
-     * @return 태그 통계 DTO 리스트
-     */
     @Query("SELECT new com.challang.backend.liquor.dto.response.TagStatDto(" +
             "    rt.tag.name AS tagName, " +
-            "    (CAST(COUNT(rt) AS double) * 100.0 / " +
-            "        (SELECT COUNT(sub) FROM ReviewTag sub WHERE sub.review.liquor.id = :liquorId)" +
-            "    )" +
+            "    (CAST(COUNT(DISTINCT rt.review.id) AS double) * 100.0 / l.reviewCount)" +
             ") " +
-            "FROM ReviewTag rt " +
-            "WHERE rt.review.liquor.id = :liquorId " +
-            "GROUP BY rt.tag.name " +
-            "ORDER BY COUNT(rt) DESC, rt.tag.name ASC")
+            "FROM ReviewTag rt JOIN rt.review.liquor l " +
+            "WHERE l.id = :liquorId " +
+            "GROUP BY rt.tag.name, l.reviewCount " +
+            "ORDER BY COUNT(DISTINCT rt.review.id) DESC, rt.tag.name ASC")
     List<TagStatDto> findTopTagStatsByLiquorId(@Param("liquorId") Long liquorId, Pageable pageable);
-
-    /**
-     * 특정 리뷰에 연결된 모든 ReviewTag를 삭제합니다.
-     * @param review 삭제할 기준이 되는 Review 엔티티
-     */
-    @Modifying // ❗ JPQL로 UPDATE, DELETE 쿼리를 실행할 때 필요합니다.
+    @Modifying
     @Query("delete from ReviewTag rt where rt.review = :review")
     void deleteByReview(@Param("review") Review review);
 

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewTagRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewTagRepository.java
@@ -1,0 +1,45 @@
+package com.challang.backend.review.repository;
+
+import com.challang.backend.liquor.dto.response.TagStatDto; // TagStatDto import
+import com.challang.backend.review.entity.Review;
+import com.challang.backend.review.entity.ReviewTag;
+import org.springframework.data.domain.Pageable; // Pageable import
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+
+import java.util.List;
+
+public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
+
+    /**
+     * 특정 주류에 대한 태그 통계를 계산하고, 가장 많이 선택된 순으로 3개까지 조회합니다.
+     * @param liquorId 주류 ID
+     * @param pageable 결과를 3개로 제한하기 위한 Pageable 객체 (e.g., PageRequest.of(0, 3))
+     * @return 태그 통계 DTO 리스트
+     */
+    @Query("SELECT new com.challang.backend.liquor.dto.response.TagStatDto(" +
+            "    rt.tag.name AS tagName, " +
+            "    (CAST(COUNT(rt) AS double) * 100.0 / " +
+            "        (SELECT COUNT(sub) FROM ReviewTag sub WHERE sub.review.liquor.id = :liquorId)" +
+            "    )" +
+            ") " +
+            "FROM ReviewTag rt " +
+            "WHERE rt.review.liquor.id = :liquorId " +
+            "GROUP BY rt.tag.name " +
+            "ORDER BY COUNT(rt) DESC, rt.tag.name ASC")
+    List<TagStatDto> findTopTagStatsByLiquorId(@Param("liquorId") Long liquorId, Pageable pageable);
+
+    /**
+     * 특정 리뷰에 연결된 모든 ReviewTag를 삭제합니다.
+     * @param review 삭제할 기준이 되는 Review 엔티티
+     */
+    @Modifying // ❗ JPQL로 UPDATE, DELETE 쿼리를 실행할 때 필요합니다.
+    @Query("delete from ReviewTag rt where rt.review = :review")
+    void deleteByReview(@Param("review") Review review);
+
+}

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewTagRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewTagRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
 
     @Query("SELECT new com.challang.backend.liquor.dto.response.TagStatDto(" +
-            "    rt.tag.name AS tagName, " +
+            "    rt.tag.name, " +
             "    (CAST(COUNT(DISTINCT rt.review.id) AS double) * 100.0 / l.reviewCount)" +
             ") " +
             "FROM ReviewTag rt JOIN rt.review.liquor l " +

--- a/backend/src/main/java/com/challang/backend/review/service/ReviewService.java
+++ b/backend/src/main/java/com/challang/backend/review/service/ReviewService.java
@@ -4,22 +4,34 @@ import com.challang.backend.global.exception.BaseException;
 import com.challang.backend.liquor.code.LiquorCode;
 import com.challang.backend.liquor.entity.Liquor;
 import com.challang.backend.liquor.repository.LiquorRepository;
+import com.challang.backend.liquor.service.LiquorService;
 import com.challang.backend.review.dto.request.*;
 import com.challang.backend.review.dto.response.*;
+import com.challang.backend.review.entity.ReactionType;
 import com.challang.backend.review.entity.Review;
+import com.challang.backend.review.entity.ReviewReaction;
+import com.challang.backend.review.entity.ReviewTag;
 import com.challang.backend.review.exception.ReviewErrorCode;
+import com.challang.backend.review.repository.ReviewReactionRepository;
 import com.challang.backend.review.repository.ReviewRepository;
+import com.challang.backend.review.repository.ReviewTagRepository;
+import com.challang.backend.tag.entity.Tag;
+import com.challang.backend.tag.repository.TagRepository;
 import com.challang.backend.user.entity.User;
 import com.challang.backend.user.exception.UserErrorCode;
 import com.challang.backend.user.repository.UserRepository;
 import com.challang.backend.util.aws.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,7 +42,11 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
     private final LiquorRepository liquorRepository;
+    private final TagRepository tagRepository;
+    private final ReviewTagRepository reviewTagRepository;
+    private final ReviewReactionRepository reviewReactionRepository;
     private final S3Service s3Service;
+    private final LiquorService liquorService;
 
     @Value("${cloud.aws.s3.url}")
     private String s3BaseUrl;
@@ -54,10 +70,18 @@ public class ReviewService {
                 .liquor(liquor)
                 .imageUrl(request.imageUrl())
                 .content(request.content())
+                .rating((double) request.rating())
                 .build();
+
+        if (request.tagIds() != null && !request.tagIds().isEmpty()) {
+            List<ReviewTag> reviewTags = createReviewTags(review, liquor, request.tagIds());
+            review.addTags(reviewTags);
+        }
 
         // 4. DB에 저장
         Review savedReview = reviewRepository.save(review);
+
+        liquorService.updateLiquorStats(liquorId);
 
         // 5. DTO로 변환하여 반환
         return ReviewResponseDto.from(savedReview, s3BaseUrl);
@@ -66,25 +90,33 @@ public class ReviewService {
     /**
      * 특정 주류의 리뷰 목록 조회
      */
-    public List<ReviewResponseDto> getReviews(Long liquorId) {
-        return reviewRepository.findByLiquorIdOrderByIdDesc(liquorId)
-                .stream()
-                .map(review -> ReviewResponseDto.from(review, s3BaseUrl))
-                .toList();
+    public Page<ReviewResponseDto> getReviewsByLiquor(Long liquorId, List<Long> tagIds, Pageable pageable) {
+        if (!liquorRepository.existsById(liquorId)) {
+            throw new BaseException(LiquorCode.LIQUOR_NOT_FOUND);
+        }
+        Page<Review> reviewPage = reviewRepository.findReviewsByLiquorAndTags(liquorId, tagIds, pageable);
+        return reviewPage.map(review -> ReviewResponseDto.from(review, s3BaseUrl));
     }
+
 
     /**
      * 리뷰 수정
      */
     @Transactional
-    public ReviewResponseDto updateReview(Long reviewId, ReviewUpdateRequestDto request, Long userId) {
-        Review review = findReview(reviewId, userId);
+    public ReviewResponseDto updateReview(Long reviewId, ReviewUpdateRequestDto request, User user) {
+        Review review = findReview(reviewId, user.getUserId());
 
         if (request.imageUrl() != null && !Objects.equals(review.getImageUrl(), request.imageUrl())) {
             s3Service.deleteByKey(review.getImageUrl());
         }
 
-        review.update(request);
+        reviewTagRepository.deleteByReview(review); // 기존 태그 연결 모두 삭제
+        List<ReviewTag> newTags = createReviewTags(review, review.getLiquor(), request.tagIds());
+        review.update(request, newTags); // update 메서드 시그니처 변경 필요
+
+        // ⭐ 주류 통계 업데이트
+        liquorService.updateLiquorStats(review.getLiquor().getId());
+
         return ReviewResponseDto.from(review, s3BaseUrl);
     }
 
@@ -92,10 +124,36 @@ public class ReviewService {
      * 리뷰 삭제
      */
     @Transactional
-    public void deleteReview(Long reviewId, Long userId) {
-        Review review = findReview(reviewId, userId);
+    public void deleteReview(Long reviewId, User user) {
+        Review review = findReview(reviewId, user.getUserId());
+        Long liquorId = review.getLiquor().getId(); // 삭제 전 liquorId 확보
+
         s3Service.deleteByKey(review.getImageUrl());
         reviewRepository.delete(review);
+
+        // ⭐ 주류 통계 업데이트
+        liquorService.updateLiquorStats(liquorId);
+    }
+
+    @Transactional
+    public void likeReview(Long reviewId, User user) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BaseException(ReviewErrorCode.REVIEW_NOT_FOUND));
+        toggleReaction(review, user, ReactionType.LIKE);
+    }
+
+    @Transactional
+    public void dislikeReview(Long reviewId, User user) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BaseException(ReviewErrorCode.REVIEW_NOT_FOUND));
+        toggleReaction(review, user, ReactionType.DISLIKE);
+    }
+
+    @Transactional
+    public void reportReview(Long reviewId, User user) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BaseException(ReviewErrorCode.REVIEW_NOT_FOUND));
+        //TODO : 신고 중복 방지 및 카운트 증가 로직 구현
     }
 
     private Review findReview(Long reviewId, Long userId) {
@@ -109,5 +167,43 @@ public class ReviewService {
         }
 
         return review;
+    }
+
+    private List<ReviewTag> createReviewTags(Review review, Liquor liquor, List<Long> tagIds) {
+        Set<Long> validTagIds = liquor.getLiquorTags().stream()
+                .map(liquorTag -> liquorTag.getTag().getId())
+                .collect(Collectors.toSet());
+
+        for (Long tagId : tagIds) {
+            if (!validTagIds.contains(tagId)) {
+                throw new BaseException(ReviewErrorCode.INVALID_TAGS_FOR_LIQUOR);
+            }
+        }
+
+        List<Tag> tags = tagRepository.findAllById(tagIds);
+        return tags.stream()
+                .map(tag -> ReviewTag.builder().review(review).tag(tag).build())
+                .collect(Collectors.toList());
+    }
+
+    private void toggleReaction(Review review, User user, ReactionType reactionType) {
+        reviewReactionRepository.findByUserAndReview(user, review)
+                .ifPresentOrElse(
+                        reaction -> { // 이미 반응이 있을 때
+                            if (reaction.getType() == reactionType) { // 같은 반응이면 취소
+                                reviewReactionRepository.delete(reaction);
+                                review.decreaseReactionCount(reactionType);
+                            } else { // 다른 반응이면 변경
+                                review.changeReaction(reaction.getType(), reactionType);
+                                reaction.updateType(reactionType);
+                            }
+                        },
+                        () -> { // 반응이 없을 때
+                            ReviewReaction newReaction = ReviewReaction.builder()
+                                    .review(review).user(user).type(reactionType).build();
+                            reviewReactionRepository.save(newReaction);
+                            review.increaseReactionCount(reactionType);
+                        }
+                );
     }
 }


### PR DESCRIPTION
## ✨ 주요 기능

- 리뷰 기능 확장: 리뷰 작성 시 평점과 해시태그(술에 등록된 태그 중 최대 3개)를 추가하는 기능
- 사용자 상호작용 추가: 각 리뷰에 대해 추천 / 비추천 / 신고를 할 수 있는 기능
- 주류 통계 정보 제공
  - 개별 주류의 평균 평점을 계산하여 표시
  - 해당 주류의 전체 리뷰 중, 상위 3개 태그가 각각 포함된 리뷰의 비율을 계산하여 표시
- 리뷰 목록 고도화
  - 태그 필터링: 특정 태그가 포함된 리뷰만 모아보기
  - 정렬: 최신순, 추천순으로 리뷰 목록 정렬.

## 🛠 변경 사항

- Entity 수정
  - Review: rating, likeCount, dislikeCount, reportCount 필드 추가
  - Liquor: averageRating, reviewCount 필드 추가
- Entity 신규 생성
  - ReviewTag: 리뷰와 태그의 다대다 관계를 위한 조인 테이블
  - ReviewReaction, ReviewReport: 추천/비추천, 신고의 중복 방지를 위한 기록 테이블
- DTO 수정
  - ReviewCreateRequestDto: rating, tagIds 필드 추가 및 태그 개수(최대 3개) 유효성 검사 적용
  - ReviewResponseDto, LiquorResponse: 확장된 기능(평점, 통계 등)을 반환하도록 수정
- Service 로직 변경
  - ReviewService: 리뷰 생성/수정/삭제 시 LiquorService의 통계 업데이트 메서드를 호출. 추천/비추천/신고 로직 구현
  - LiquorService: 주류 통계(평균 평점, 태그 비율)를 계산하고 업데이트하는 updateLiquorStats 메서드 신규 생성
- Repository 및 QueryDSL
  - ReviewRepositoryCustom 및 ReviewRepositoryImpl을 구현하여, 태그 필터링 및 정렬을 위한 동적 쿼리 작성
  - ReviewTagRepository에 통계 계산을 위한 JPQL 쿼리 추가

## 🔗 엔드포인트

- GET /api/liquors/{liquorId}/reviews
  - RequestParam으로 tagIds(필터링)와 pageable(정렬, 페이징)을 받도록 수정
- GET /api/liquors/{id}
  - 응답(Response)에 averageRating, topTagStats 등 통계 정보 추가
- POST /api/reviews/{reviewId}/like (신규)
  - 리뷰 추천 및 취소
- POST /api/reviews/{reviewId}/dislike (신규)
  - 리뷰 비추천 및 취소
- POST /api/reviews/{reviewId}/report (신규)
  -  리뷰 신고


closes #44 