### PR TITLE
feat: 술 검색 기능 구현

### DIFF
--- a/backend/src/main/java/com/challang/backend/liquor/controller/LiquorController.java
+++ b/backend/src/main/java/com/challang/backend/liquor/controller/LiquorController.java
@@ -45,16 +45,17 @@ public class LiquorController {
         return ResponseEntity.ok(new BaseResponse<>(response));
     }
 
-    @Operation(summary = "주류 전체 조회", description = "이름 기준 커서 방식으로 주류 목록을 조회합니다.")
+    @Operation(summary = "주류 전체 조회", description = "이름 또는 태그 기준 키워드 검색과 커서 방식으로 주류 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "주류 전체 조회 성공")
     })
     @GetMapping
     public ResponseEntity<BaseResponse<LiquorListResponse>> findAll(
             @RequestParam(required = false) String cursorName,
-            @RequestParam(defaultValue = "10") Integer pageSize
+            @RequestParam(defaultValue = "10") Integer pageSize,
+            @RequestParam(required = false) String keyword
     ) {
-        LiquorListResponse response = liquorService.findAll(cursorName, pageSize);
+        LiquorListResponse response = liquorService.findAll(cursorName, pageSize, keyword);
         return ResponseEntity.ok(new BaseResponse<>(response));
     }
 

--- a/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
+++ b/backend/src/main/java/com/challang/backend/liquor/repository/LiquorRepository.java
@@ -31,11 +31,21 @@ public interface LiquorRepository extends JpaRepository<Liquor, Long> {
                 LEFT JOIN FETCH l.level
                 LEFT JOIN FETCH l.type
                 LEFT JOIN FETCH l.liquorTags lt
-                LEFT JOIN FETCH lt.tag
+                LEFT JOIN FETCH lt.tag t
                 WHERE (:cursor IS NULL OR l.name < :cursor)
-                ORDER BY l.name DESC
+                AND (
+                    :keyword IS NULL
+                    OR LOWER(l.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                    OR LOWER(t.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                )
+                ORDER BY l.name ASC
             """)
-    List<Liquor> findAllWithTagsByCursor(@Param("cursor") String cursor, Pageable pageable);
+    List<Liquor> findAllWithTagsByCursor(
+            @Param("cursor") String cursor,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
 
     @Query("""
                 SELECT DISTINCT l FROM Liquor l

--- a/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
+++ b/backend/src/main/java/com/challang/backend/liquor/service/LiquorService.java
@@ -92,10 +92,10 @@ public class LiquorService {
 
     // 주류 전체 조회
     @Transactional(readOnly = true)
-    public LiquorListResponse findAll(String cursorName, Integer pageSize) {
+    public LiquorListResponse findAll(String cursorName, Integer pageSize,  String keyword) {
         Pageable pageable = PageRequest.of(0, pageSize + 1); // +1: 다음 페이지 여부 확인용
 
-        List<Liquor> liquors = liquorRepository.findAllWithTagsByCursor(cursorName, pageable);
+        List<Liquor> liquors = liquorRepository.findAllWithTagsByCursor(cursorName, keyword, pageable);
 
         boolean hasNext = liquors.size() > pageSize;
         if (hasNext) {


### PR DESCRIPTION
### ✨ 주요 기능

- 주류 목록 조회 시 `keyword` 파라미터를 통해 이름 또는 태그 기반 검색 가능
- 검색 대상:
  - 주류 이름 (`liquor.name`)
  - 스타일 태그 이름 (`tag.name`)
- 검색 방식:
  - 부분 일치 검색 (`LIKE %keyword%`)
  - 대소문자 구분 없음
- 검색어가 없을 경우 기존과 동일하게 전체 주류 목록 반환
- 커서 기반 페이징 형식 유지

---

### 🛠 변경 사항

- `GET /api/liquors`에 `keyword` 파라미터 추가
- `LiquorService.findAll()`에 `keyword` 인자 추가
- Swagger 문서 설명 문구 수정