### PR TITLE
feat: 탈퇴 기능 추가

### DIFF
--- a/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
+++ b/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
@@ -48,6 +48,8 @@ public interface ArchiveRepository extends JpaRepository<Archive, Long> {
     // 술 id만 얻는 용도 => joinX
     List<Archive> findByUser(User user);
 
+    long countByUser(User user);
+
     @Modifying
     @Query("DELETE FROM Archive a WHERE a.user = :user")
     void deleteAllByUser(@Param("user") User user);

--- a/backend/src/main/java/com/challang/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/challang/backend/auth/controller/AuthController.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import com.challang.backend.auth.dto.request.UserDeletionRequest;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Auth API", description = "사용자 회원가입, 로그인 등 인증 관련 API")
 @RestController
@@ -92,10 +94,11 @@ public class AuthController {
     public ResponseEntity<BaseResponse<String>> deleteUser(
             @Parameter(description = "로그인 시 발급받은 Refresh Token", required = true)
             @RequestHeader(name = "Refresh-Token") String refreshToken,
+            @RequestBody @Valid UserDeletionRequest deletionRequest,
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        authService.deleteUser(userDetails.getUserId(), refreshToken);
+        authService.deleteUser(userDetails.getUserId(), refreshToken, deletionRequest.getReason());
         return ResponseEntity.ok(new BaseResponse<>("회원 탈퇴 완료"));
     }
 

--- a/backend/src/main/java/com/challang/backend/auth/dto/request/UserDeletionRequest.java
+++ b/backend/src/main/java/com/challang/backend/auth/dto/request/UserDeletionRequest.java
@@ -1,0 +1,16 @@
+package com.challang.backend.auth.dto.request;
+
+import com.challang.backend.withdrawal.entity.ReasonType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDeletionRequest {
+
+    @NotNull(message = "탈퇴 사유는 필수입니다.")
+    @Schema(description = "회원 탈퇴 사유", implementation = ReasonType.class)
+    private ReasonType reason;
+}

--- a/backend/src/main/java/com/challang/backend/review/entity/Review.java
+++ b/backend/src/main/java/com/challang/backend/review/entity/Review.java
@@ -55,6 +55,12 @@ public class Review extends BaseEntity {
     @Builder.Default
     private List<ReviewTag> reviewTags = new ArrayList<>();
 
+    @OneToMany(mappedBy = "review", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ReviewReport> reports = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ReviewReaction> reactions = new ArrayList<>();
+
     public void update(ReviewUpdateRequestDto request, List<ReviewTag> newTags) {
         if (request.content() != null) {
             this.content = request.content();

--- a/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/challang/backend/review/repository/ReviewRepository.java
@@ -25,6 +25,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     // 술 id만 얻는 용도 => joinX
     List<Review> findByWriter(User user);
 
+    long countByWriter(User writer);
+
     @Modifying
     @Query("DELETE FROM Review r WHERE r.writer = :writer")
     void deleteAllByWriter(@Param("writer") User writer);

--- a/backend/src/main/java/com/challang/backend/review/service/ReviewService.java
+++ b/backend/src/main/java/com/challang/backend/review/service/ReviewService.java
@@ -132,6 +132,9 @@ public class ReviewService {
         Review review = findReview(reviewId, user.getUserId());
         Long liquorId = review.getLiquor().getId(); // 삭제 전 liquorId 확보
 
+        reviewReportRepository.deleteAllByReview(review);
+        reviewReactionRepository.deleteAllByReview(review);
+
         s3Service.deleteByKey(review.getImageUrl());
         reviewRepository.delete(review);
 

--- a/backend/src/main/java/com/challang/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/challang/backend/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.challang.backend.user.controller;
+
+import com.challang.backend.auth.annotation.CurrentUser;
+import com.challang.backend.user.dto.UserActivityCountsResponse;
+import com.challang.backend.user.entity.User;
+import com.challang.backend.user.service.UserService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "사용자 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "사용자 활동 수 조회", description = "현재 로그인된 사용자가 찜한 주류와 작성한 리뷰의 총 개수를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/activity-counts")
+    public ResponseEntity<BaseResponse<UserActivityCountsResponse>> getUserActivityCounts(@CurrentUser User user) {
+        UserActivityCountsResponse response = userService.getUserActivityCounts(user.getUserId());
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/user/dto/UserActivityCountsResponse.java
+++ b/backend/src/main/java/com/challang/backend/user/dto/UserActivityCountsResponse.java
@@ -1,0 +1,7 @@
+package com.challang.backend.user.dto;
+
+public record UserActivityCountsResponse(
+        long likedCurationCount,
+        long writtenReviewCount
+) {
+}

--- a/backend/src/main/java/com/challang/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/challang/backend/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.challang.backend.review.repository.ReviewReactionRepository;
 import com.challang.backend.review.repository.ReviewReportRepository;
 import com.challang.backend.review.repository.ReviewRepository;
 import com.challang.backend.review.repository.ReviewTagRepository;
+import com.challang.backend.user.dto.UserActivityCountsResponse;
 import com.challang.backend.user.entity.User;
 import com.challang.backend.user.exception.UserErrorCode;
 import com.challang.backend.user.repository.UserRepository;
@@ -46,6 +47,17 @@ public class UserService implements UserDetailsService {
 
     public User getByLoginId(Long id) {
         return userRepository.findById(id).orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public UserActivityCountsResponse getUserActivityCounts(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+
+        long likedCurationCount = archiveRepository.countByUser(user);
+        long writtenReviewCount = reviewRepository.countByWriter(user);
+
+        return new UserActivityCountsResponse(likedCurationCount, writtenReviewCount);
     }
 
     @Transactional

--- a/backend/src/main/java/com/challang/backend/withdrawal/controller/WithdrawalController.java
+++ b/backend/src/main/java/com/challang/backend/withdrawal/controller/WithdrawalController.java
@@ -1,0 +1,32 @@
+package com.challang.backend.withdrawal.controller;
+
+import com.challang.backend.util.response.BaseResponse;
+import com.challang.backend.withdrawal.dto.WithdrawalReasonResponse;
+import com.challang.backend.withdrawal.service.WithdrawalReasonService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Admin API", description = "관리자 전용 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class WithdrawalController {
+
+    private final WithdrawalReasonService withdrawalReasonService;
+
+    @Operation(summary = "[관리자] 탈퇴 사유 목록 조회", description = "모든 사용자의 탈퇴 사유를 조회합니다.")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/withdrawal-reasons")
+    public ResponseEntity<BaseResponse<List<WithdrawalReasonResponse>>> getWithdrawalReasons() {
+        List<WithdrawalReasonResponse> response = withdrawalReasonService.getAllWithdrawalReasons();
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/withdrawal/dto/WithdrawalReasonResponse.java
+++ b/backend/src/main/java/com/challang/backend/withdrawal/dto/WithdrawalReasonResponse.java
@@ -1,0 +1,22 @@
+package com.challang.backend.withdrawal.dto;
+
+import com.challang.backend.withdrawal.entity.ReasonType;
+import com.challang.backend.withdrawal.entity.WithdrawalReason;
+
+import java.time.LocalDateTime;
+
+public record WithdrawalReasonResponse(
+        Long id,
+        Long userId,
+        ReasonType reason,
+        LocalDateTime createdAt
+) {
+    public static WithdrawalReasonResponse from(WithdrawalReason withdrawalReason) {
+        return new WithdrawalReasonResponse(
+                withdrawalReason.getId(),
+                withdrawalReason.getUserId(),
+                withdrawalReason.getReason(),
+                withdrawalReason.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/challang/backend/withdrawal/entity/ReasonType.java
+++ b/backend/src/main/java/com/challang/backend/withdrawal/entity/ReasonType.java
@@ -1,0 +1,12 @@
+package com.challang.backend.withdrawal.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 탈퇴 사유 (SERVICE_DISSATISFACTION: 서비스 불만족, APP_ERROR: 앱 오류, LACK_OF_INFORMATION: 정보의 부족, REJOIN_WITH_OTHER_ACCOUNT: 다른 계정으로 재가입, OTHER: 기타)")
+public enum ReasonType {
+    SERVICE_DISSATISFACTION, // 서비스 불만족
+    APP_ERROR,               // 앱 오류
+    LACK_OF_INFORMATION,     // 정보의 부족
+    REJOIN_WITH_OTHER_ACCOUNT, // 다른 계정으로 재가입
+    OTHER                    // 기타
+}

--- a/backend/src/main/java/com/challang/backend/withdrawal/entity/WithdrawalReason.java
+++ b/backend/src/main/java/com/challang/backend/withdrawal/entity/WithdrawalReason.java
@@ -1,0 +1,32 @@
+package com.challang.backend.withdrawal.entity;
+
+import com.challang.backend.util.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "withdrawal_reason")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawalReason extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false)
+    private ReasonType reason;
+
+    @Builder
+    public WithdrawalReason(Long userId, ReasonType reason) {
+        this.userId = userId;
+        this.reason = reason;
+    }
+}

--- a/backend/src/main/java/com/challang/backend/withdrawal/repository/WithdrawalReasonRepository.java
+++ b/backend/src/main/java/com/challang/backend/withdrawal/repository/WithdrawalReasonRepository.java
@@ -1,0 +1,9 @@
+package com.challang.backend.withdrawal.repository;
+
+import com.challang.backend.withdrawal.entity.WithdrawalReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WithdrawalReasonRepository extends JpaRepository<WithdrawalReason, Long> {
+}

--- a/backend/src/main/java/com/challang/backend/withdrawal/service/WithdrawalReasonService.java
+++ b/backend/src/main/java/com/challang/backend/withdrawal/service/WithdrawalReasonService.java
@@ -1,0 +1,24 @@
+package com.challang.backend.withdrawal.service;
+
+import com.challang.backend.withdrawal.dto.WithdrawalReasonResponse;
+import com.challang.backend.withdrawal.repository.WithdrawalReasonRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WithdrawalReasonService {
+
+    private final WithdrawalReasonRepository withdrawalReasonRepository;
+
+    public List<WithdrawalReasonResponse> getAllWithdrawalReasons() {
+        return withdrawalReasonRepository.findAll().stream()
+                .map(WithdrawalReasonResponse::from)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## ✨ 주요 기능

- 회원 탈퇴 기능 개선
  - 사용자가 회원 탈퇴 시, 탈퇴 사유를 선택하고 시스템에 저장하는 기능 추가
  - 회원 탈퇴 페이지에서 사용자가 찜했던 주류(큐레이팅) 수와 작성했던 리뷰 수를 확인할 수 있는 기능을 추가

## 🛠 변경 사항
- AuthService 수정
- UserController 수정
  - getUserActivityCounts 메소드를 구현하여 ArchiveRepository와 ReviewRepository에서 관련 데이터를 조회
- UserService 수정
- Withdrawal 관련 클래스 추가
  - 탈퇴 사유를 저장하기 위한 WithdrawalReason 엔티티, WithdrawalReasonRepository 레포지토리, ReasonType enum
- Entity 수정

## 🔗 엔드포인트

- GET /api/users/activity-counts : 현재 로그인된 사용자가 찜한 주류와 작성한 리뷰의 총 개수를 조회
- DELETE /api/auth/user : 회원 탈퇴를 진행하며, 요청 본문에 탈퇴 사유를 포함
- GET /api/admin/withdrawal-reasons] : 모든 사용자의 탈퇴 사유를 조회

closes #53 