### PR TITLE
Feature/betapa/rank

### DIFF
--- a/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
+++ b/backend/src/main/java/com/challang/backend/archive/repository/ArchiveRepository.java
@@ -5,6 +5,7 @@ import com.challang.backend.liquor.entity.Liquor;
 import com.challang.backend.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ArchiveRepository extends JpaRepository<Archive, Long> {
 
+    @Query("SELECT a.liquor.id, COUNT(a) as archiveCount FROM Archive a GROUP BY a.liquor.id ORDER BY archiveCount DESC")
+    List<Object[]> findTop8ArchivedLiquors(Pageable pageable);
 
     Optional<Archive> findByUserAndLiquor(User user, Liquor liquor);
     boolean existsByUserAndLiquor(User user, Liquor liquor);

--- a/backend/src/main/java/com/challang/backend/ranking/controller/RankingController.java
+++ b/backend/src/main/java/com/challang/backend/ranking/controller/RankingController.java
@@ -1,0 +1,30 @@
+package com.challang.backend.ranking.controller;
+
+import com.challang.backend.ranking.dto.RankingResponseDto;
+import com.challang.backend.ranking.service.RankingService;
+import com.challang.backend.util.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Ranking", description = "랭킹 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ranking")
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    @Operation(summary = "인기 주류 랭킹 TOP 8 조회", description = "사용자들이 가장 많이 찜한 주류 순으로 8개를 조회합니다.")
+    @GetMapping("/top8")
+    public ResponseEntity<BaseResponse<List<RankingResponseDto>>> getTop8ArchivedLiquors() {
+        List<RankingResponseDto> response = rankingService.getTop8ArchivedLiquors();
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+}

--- a/backend/src/main/java/com/challang/backend/ranking/dto/RankingResponseDto.java
+++ b/backend/src/main/java/com/challang/backend/ranking/dto/RankingResponseDto.java
@@ -1,0 +1,17 @@
+package com.challang.backend.ranking.dto;
+
+import com.challang.backend.liquor.entity.Liquor;
+import lombok.Getter;
+
+@Getter
+public class RankingResponseDto {
+    private final Long liquorId;
+    private final String name;
+    private final Long archiveCount;
+
+    public RankingResponseDto(Liquor liquor, Long archiveCount, String s3BaseUrl) {
+        this.liquorId = liquor.getId();
+        this.name = liquor.getName();
+        this.archiveCount = archiveCount;
+    }
+}

--- a/backend/src/main/java/com/challang/backend/ranking/dto/RankingResponseDto.java
+++ b/backend/src/main/java/com/challang/backend/ranking/dto/RankingResponseDto.java
@@ -9,7 +9,7 @@ public class RankingResponseDto {
     private final String name;
     private final Long archiveCount;
 
-    public RankingResponseDto(Liquor liquor, Long archiveCount, String s3BaseUrl) {
+    public RankingResponseDto(Liquor liquor, Long archiveCount) {
         this.liquorId = liquor.getId();
         this.name = liquor.getName();
         this.archiveCount = archiveCount;

--- a/backend/src/main/java/com/challang/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/challang/backend/ranking/service/RankingService.java
@@ -1,0 +1,43 @@
+package com.challang.backend.ranking.service;
+
+import com.challang.backend.archive.repository.ArchiveRepository;
+import com.challang.backend.liquor.entity.Liquor;
+import com.challang.backend.liquor.repository.LiquorRepository;
+import com.challang.backend.ranking.dto.RankingResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RankingService {
+
+    private final ArchiveRepository archiveRepository;
+    private final LiquorRepository liquorRepository;
+
+    @Value("${cloud.aws.s3.url}")
+    private String s3BaseUrl;
+
+    public List<RankingResponseDto> getTop8ArchivedLiquors() {
+        List<Object[]> results = archiveRepository.findTop8ArchivedLiquors(PageRequest.of(0, 8));
+
+        return results.stream()
+                .map(result -> {
+                    Long liquorId = (Long) result[0];
+                    Long archiveCount = (Long) result[1];
+                    Liquor liquor = liquorRepository.findById(liquorId).orElse(null);
+                    if (liquor != null) {
+                        return new RankingResponseDto(liquor, archiveCount, s3BaseUrl);
+                    }
+                    return null;
+                })
+                .filter(dto -> dto != null)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/challang/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/challang/backend/ranking/service/RankingService.java
@@ -21,9 +21,6 @@ public class RankingService {
     private final ArchiveRepository archiveRepository;
     private final LiquorRepository liquorRepository;
 
-    @Value("${cloud.aws.s3.url}")
-    private String s3BaseUrl;
-
     public List<RankingResponseDto> getTop8ArchivedLiquors() {
         List<Object[]> results = archiveRepository.findTop8ArchivedLiquors(PageRequest.of(0, 8));
 
@@ -33,7 +30,7 @@ public class RankingService {
                     Long archiveCount = (Long) result[1];
                     Liquor liquor = liquorRepository.findById(liquorId).orElse(null);
                     if (liquor != null) {
-                        return new RankingResponseDto(liquor, archiveCount, s3BaseUrl);
+                        return new RankingResponseDto(liquor, archiveCount);
                     }
                     return null;
                 })


### PR DESCRIPTION
## ✨ 주요 기능

- 실시간 인기 주류 랭킹 TOP 8 조회 기능 추가

## 🛠 변경 사항
- `RankingController`, `RankingService`, `RankingResponseDto` 추가
- `ArchiveRepository` 수정 - 찜한 횟수가 가장 많은 상위 8개의 주류 ID와 찜한 횟수를 조회하는 JPQL 쿼리

## 🔗 엔드포인트

- GET /api/ranking/top8: 사용자들이 가장 많이 찜한 주류 순으로 상위 8개를 조회합니다.

closes #54 