### PR TITLE
feat: 로그인 응답에 선호 설정 여부 추가

### DIFF
--- a/backend/src/main/java/com/challang/backend/auth/dto/response/TokenResponse.java
+++ b/backend/src/main/java/com/challang/backend/auth/dto/response/TokenResponse.java
@@ -1,9 +1,11 @@
 package com.challang.backend.auth.dto.response;
 
 
-import lombok.Getter;
-
 public record TokenResponse(
         String accessToken,
-        String refreshToken) {
+        String refreshToken,
+        boolean isPreferenceSet) {
+    public TokenResponse(String accessToken, String refreshToken) {
+        this(accessToken, refreshToken, false); // 기본값 false
+    }
 }

--- a/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceLevelRepository.java
+++ b/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceLevelRepository.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Repository;
 public interface LiquorPreferenceLevelRepository extends JpaRepository<LiquorPreferenceLevel, Long> {
     List<LiquorPreferenceLevel> findByUser(User user);
 
+    boolean existsByUser(User user);
+
     @Modifying
     @Query("DELETE FROM LiquorPreferenceLevel lpl WHERE lpl.user = :user")
     void deleteAllByUser(@Param("user") User user);

--- a/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTagRepository.java
+++ b/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTagRepository.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LiquorPreferenceTagRepository extends JpaRepository<LiquorPreferenceTag, Long> {
     boolean existsByUserAndTag(User user, Tag tag);
-
+    boolean existsByUser(User user);
     List<LiquorPreferenceTag> findByUser(User user);
 
     @Modifying

--- a/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTypeRepository.java
+++ b/backend/src/main/java/com/challang/backend/preference/repository/LiquorPreferenceTypeRepository.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LiquorPreferenceTypeRepository extends JpaRepository<LiquorPreferenceType, Long> {
     boolean existsByUserAndLiquorType(User user, LiquorType liquorType);
-
+    boolean existsByUser(User user);
     List<LiquorPreferenceType> findByUser(User user);
 
     @Modifying


### PR DESCRIPTION
## ✨ 주요 기능
- `TokenResponse`에 `isPreferenceSet` 필드 추가
- 카카오 로그인(`kakaoSignIn`) 시, 해당 유저의 선호 설정 여부를 판단하여 응답에 포함

## 🛠 변경 사항
- `TokenResponse` record에 `boolean isPreferenceSet` 필드 추가
- `kakaoSignIn` 메서드 내에 선호 설정 여부 판단 로직 추가 (`LiquorPreferenceLevel`, `Type`, `Tag`가 모두 존재할 때만 true)
- `TokenResponse` 생성자 오버로딩 추가 (재발급 시 isPreferenceSet 생략 가능)

## ✅ 기타 참고 사항
- 토큰 재발급 API(`reissueTokens`)에서는 `isPreferenceSet` 포함하지 않음 (기본 false 처리)
