### PR TITLE
feat: 큐레이팅 화면에 추천 주류 API 연동

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(libs.v2.cert) // 카카오 인증서비스
 
     implementation(libs.glide) // 이미지 핸들링 라이브러리 Glide
+    implementation(libs.coil.compose)
 
     implementation(libs.retrofit)
     implementation(libs.converter.gson)

--- a/frontend/app/src/main/java/com/stellan/challang/MainActivity.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/MainActivity.kt
@@ -69,3 +69,9 @@ suspend fun Context.setGuideShown() {
         prefs[GUIDE_SHOWN_KEY] = true
     }
 }
+
+suspend fun Context.setGuideShown(value: Boolean) {
+    dataStore.edit { prefs ->
+        prefs[GUIDE_SHOWN_KEY] = value
+    }
+}

--- a/frontend/app/src/main/java/com/stellan/challang/data/api/ApiClient.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/data/api/ApiClient.kt
@@ -51,4 +51,8 @@ object ApiClient {
     val userApi: UserApiService by lazy {
         retrofit.create(UserApiService::class.java)
     }
+
+    val drinkApi: DrinkApiService by lazy {
+        retrofit.create(DrinkApiService::class.java)
+    }
 }

--- a/frontend/app/src/main/java/com/stellan/challang/data/api/DrinkApiService.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/data/api/DrinkApiService.kt
@@ -1,0 +1,14 @@
+package com.stellan.challang.data.api
+
+import com.stellan.challang.data.model.drink.DrinkResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+interface DrinkApiService {
+    @GET("api/recommend")
+    suspend fun getRecommendedDrinks(
+        @Header("Authorization") token: String
+    ): Response<DrinkResponse>
+
+}

--- a/frontend/app/src/main/java/com/stellan/challang/data/model/drink/Drink.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/data/model/drink/Drink.kt
@@ -1,0 +1,30 @@
+package com.stellan.challang.data.model.drink
+
+data class Drink(
+    val id: Int,
+    val name: String,
+    val imageUrl: String,
+    val tastingNote: String,
+    val origin: String,
+    val minAbv: Double,
+    val maxAbv: Double,
+    val levelId: Int,
+    val levelName: String,
+    val typeId: Int,
+    val typeName: String,
+    val liquorTags: List<LiquorTag>,
+    val averageRating: Double,
+    val topTagStats: List<TopTagStat>
+)
+
+data class LiquorTag(
+    val id: Int,
+    val tagId: Int,
+    val tagName: String,
+    val isCore: Boolean
+)
+
+data class TopTagStat(
+    val tagName: String,
+    val percentage: Double
+)

--- a/frontend/app/src/main/java/com/stellan/challang/data/model/drink/DrinkResponse.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/data/model/drink/DrinkResponse.kt
@@ -1,0 +1,9 @@
+package com.stellan.challang.data.model.drink
+
+data class DrinkResponse(
+    val httpStatus: String,
+    val isSuccess: Boolean,
+    val message: String,
+    val code: Int,
+    val result: List<Drink>?
+)

--- a/frontend/app/src/main/java/com/stellan/challang/data/repository/DrinkRepository.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/data/repository/DrinkRepository.kt
@@ -1,0 +1,26 @@
+package com.stellan.challang.data.repository
+
+import com.stellan.challang.data.api.DrinkApiService
+import com.stellan.challang.data.model.drink.Drink
+
+class DrinkRepository(
+    private val apiService: DrinkApiService
+) {
+    suspend fun getRecommendedDrinks(token: String): List<Drink> {
+        val response = apiService.getRecommendedDrinks(token);
+
+        return when {
+            response.isSuccessful && response.body() != null -> {
+                response.body()!!.result!!
+            }
+
+            response.code() == 401 -> {
+                throw Exception("인증 실패: 토큰이 유효하지 않거나 만료됨 (401)")
+            }
+
+            else -> {
+                throw Exception("주류 추천 실패: ${response.code()} - ${response.message()}")
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/stellan/challang/ui/navigation/HomeNavGraph.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/navigation/HomeNavGraph.kt
@@ -1,36 +1,44 @@
 package com.stellan.challang.ui.navigation
 
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
+import com.stellan.challang.data.api.ApiClient
+import com.stellan.challang.data.repository.DrinkRepository
 import com.stellan.challang.ui.screen.home.*
+import com.stellan.challang.ui.viewmodel.DrinkViewModel
 
 fun NavGraphBuilder.homeNavGraph(
     rootNavController: NavHostController,
-    bottomNavController: NavHostController
+    bottomNavController: NavHostController,
+    drinkViewModel: DrinkViewModel
 ) {
     navigation(startDestination = "curating", route = "home") {
         composable("curating") {
             CuratingScreen(
-                onDetail = { drinkId ->
-                    bottomNavController.navigate("detail/$drinkId")
+                onDetail = { drink ->
+                    drinkViewModel.selectDrink(drink)
+                    bottomNavController.navigate("detail")
                 }
             )
         }
-        composable(
-            "detail/{drinkId}",
-            arguments = listOf(navArgument("drinkId") { type = NavType.StringType })
-        ) { backStack ->
-            val drinkId = backStack.arguments!!.getString("drinkId")!!
-            DrinkDetailScreen(
-                drinkId = drinkId,
-                onViewReviews = {
-                    bottomNavController.navigate("reviews/$drinkId")
-                }
-            )
+        composable("detail") {
+            val selectedDrink by drinkViewModel.selectedDrink.collectAsState()
+
+            selectedDrink?.let { drink ->
+                DrinkDetailScreen(
+                    drink = drink,
+                    onViewReviews = {
+                        bottomNavController.navigate("reviews/${drink.id}")
+                    }
+                )
+            }
         }
         composable(
             "reviews/{drinkId}",

--- a/frontend/app/src/main/java/com/stellan/challang/ui/navigation/MainNavGraph.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/navigation/MainNavGraph.kt
@@ -4,10 +4,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.stellan.challang.ui.screen.archive.ArchiveScreen
+import com.stellan.challang.ui.viewmodel.DrinkViewModel
 
 fun NavGraphBuilder.mainNavGraph(rootNavController: NavHostController,
-                                 bottomNavController: NavHostController) {
-    homeNavGraph(rootNavController, bottomNavController)
+                                 bottomNavController: NavHostController,
+                                 drinkViewModel: DrinkViewModel
+) {
+    homeNavGraph(rootNavController, bottomNavController, drinkViewModel)
     composable("archive") { ArchiveScreen() }
     myPageNavGraph(rootNavController, bottomNavController)
 }

--- a/frontend/app/src/main/java/com/stellan/challang/ui/screen/auth/LoginScreen.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/screen/auth/LoginScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/frontend/app/src/main/java/com/stellan/challang/ui/screen/auth/ProfileSettingScreen.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/screen/auth/ProfileSettingScreen.kt
@@ -1,5 +1,6 @@
 package com.stellan.challang.ui.screen.auth
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -50,20 +51,20 @@ import kotlin.math.*
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.remember
-import androidx. compose. ui. tooling. preview. Preview
-import androidx. compose. foundation. rememberScrollState
-import androidx. compose. foundation. verticalScroll
-import com. stellan. challang. ui. viewmodel. TagViewModel
-import com. stellan. challang. data. api.ApiClient
-import  com. stellan. challang. data. repository. TagRepository
-import com. stellan. challang. data. model. auth. TokenProvider
-import com. stellan. challang. data. model. Preference. PreferenceRequest
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import com.stellan.challang.ui.viewmodel.TagViewModel
+import com.stellan.challang.data.api.ApiClient
+import  com.stellan.challang.data.repository.TagRepository
+import com.stellan.challang.data.model.auth.TokenProvider
+import com.stellan.challang.data.model.Preference.PreferenceRequest
 import com.stellan.challang.data.repository.PreferenceRepository
-import  kotlinx. coroutines. CoroutineScope
-import kotlinx. coroutines. Dispatchers
-import  kotlinx. coroutines. launch
-import kotlinx. coroutines. withContext
-import android. util. Log
+import  kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import  kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import android.util.Log
 import com.stellan.challang.ui.viewmodel.PreferenceViewModel
 
 //@Composable
@@ -148,6 +149,7 @@ import com.stellan.challang.ui.viewmodel.PreferenceViewModel
 //        )
 //    }
 //}
+@SuppressLint("RememberReturnType")
 @Composable
 fun ProfileSettingScreen(
     onProfileComplete: () -> Unit
@@ -177,15 +179,18 @@ fun ProfileSettingScreen(
             onNext = { step = 2 },
             onTypeSelected = { selectedTypeIds = it }
         )
+
         2 -> ProfileStepTwo(
             onValueSelected = { selectedLevelId = it },
             onNext = { step = 3 }
         )
+
         3 -> ProfileStepThree(
             viewModel = tagViewModel,
             onNext = { step = 4 },
             onTagSelected = { selectedTagIds = it }
         )
+
         4 -> ProfileStepFour(
             onNext = {
                 val token = TokenProvider.getRefreshToken() ?: return@ProfileStepFour
@@ -204,8 +209,6 @@ fun ProfileSettingScreen(
         Log.e("PreferenceSubmit", "에러: $it")
     }
 }
-
-
 
 
 @Composable
@@ -277,10 +280,10 @@ fun ProfileStepOne(
                         tonalElevation = if (isSelected) 4.dp else 0.dp,
                         modifier = Modifier
                             .size(width = 105.dp, height = 57.dp)
-                            .clickable (
+                            .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
                                 indication = null
-                            ){
+                            ) {
                                 if (isSelected) {
                                     selectedIds.remove(id)
                                     selectedOptions.remove(option)
@@ -321,13 +324,15 @@ fun ProfileStepOne(
                         }
                     },
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = if (isSelectionEnough) Color(0xFFB2DADA) else Color(0xFFDDF0F0)
+                        containerColor = if (isSelectionEnough) Color(0xFFB2DADA) else Color(
+                            0xFFDDF0F0
+                        )
                     ),
                     shape = RoundedCornerShape(10.dp),
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(48.dp)
-                )  {
+                ) {
                     Text(
                         "다음",
                         fontFamily = PaperlogyFamily,
@@ -348,8 +353,10 @@ fun ProfileStepTwo(
     onNext: () -> Unit
 ) {
     val levels = listOf("고도수", "중도수", "저도수")
-    val descriptions = listOf("최저 도수 기준 25% 초과",
-        "최저 도수 기준 15% 초과~25% 이하", "최저 도수 기준 15% 이하")
+    val descriptions = listOf(
+        "최저 도수 기준 25% 초과",
+        "최저 도수 기준 15% 초과~25% 이하", "최저 도수 기준 15% 이하"
+    )
     var sliderValue by remember { mutableFloatStateOf(1f) }
     val selectedIndex = sliderValue.roundToInt()
     val isSelectionMade = sliderValue in 0f..2f
@@ -474,7 +481,7 @@ fun ProfileStepTwo(
             Button(
                 onClick = {
                     if (isSelectionMade) {
-                        onValueSelected(selectedIndex+1) // 🔼 선택값 전달!
+                        onValueSelected(selectedIndex + 1) // 🔼 선택값 전달!
                         onNext()
                     }
                 },
@@ -497,7 +504,6 @@ fun ProfileStepTwo(
         }
     }
 }
-
 
 
 @Composable
@@ -568,52 +574,54 @@ fun ProfileStepThree(
                     .height(460.dp) // 고정 높이
                     .verticalScroll(rememberScrollState()) // 세로 스크롤 적용
             ) {
-            FlowRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy((4).dp, Alignment.Start),
-                verticalArrangement = Arrangement.spacedBy((2).dp)
-            ) {
-                alcoholOptions.forEach { option ->
-                    val isSelected = selectedOptions.contains(option)
-                    Surface(
-                        shape = CircleShape,
-                        color = if (isSelected) Color(0xFFB2DADA) else Color(0xFFDDF0F0),
-                        tonalElevation = if (isSelected) 4.dp else 0.dp,
-                        modifier = Modifier
-//                            .size(width = 100.dp, height = 57.dp)
-                            .height(57.dp)
-                            .defaultMinSize(minWidth = 100.dp)
-                            .wrapContentWidth(unbounded = true)
-                            .clickable (
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null){
-                                if (isSelected) {
-                                    selectedOptions.remove(option)
-                                } else if (selectedOptions.size < 5) {
-                                    selectedOptions.add(option)
-                                }
-                            }
-                            .padding(horizontal = 2.dp, vertical = 8.dp)
-                    ) {
-                        Box(
-//                            modifier = Modifier.fillMaxSize(),
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy((4).dp, Alignment.Start),
+                    verticalArrangement = Arrangement.spacedBy((2).dp)
+                ) {
+                    alcoholOptions.forEach { option ->
+                        val isSelected = selectedOptions.contains(option)
+                        Surface(
+                            shape = CircleShape,
+                            color = if (isSelected) Color(0xFFB2DADA) else Color(0xFFDDF0F0),
+                            tonalElevation = if (isSelected) 4.dp else 0.dp,
                             modifier = Modifier
-                                .padding(horizontal = 15.dp, vertical = 5.dp),
-                            contentAlignment = Alignment.Center
+//                            .size(width = 100.dp, height = 57.dp)
+                                .height(57.dp)
+                                .defaultMinSize(minWidth = 100.dp)
+                                .wrapContentWidth(unbounded = true)
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) {
+                                    if (isSelected) {
+                                        selectedOptions.remove(option)
+                                    } else {
+                                        selectedOptions.add(option)
+                                    }
+                                }
+                                .padding(horizontal = 2.dp, vertical = 8.dp)
                         ) {
-                            Text(
-                                text = option,
-                                fontFamily = PaperlogyFamily,
-                                fontWeight = FontWeight.Normal,
-                                fontSize = 14.sp,
-                                color = Color.Black,
-                                textAlign = TextAlign.Center,
-                                maxLines = 1
-                            )
+                            Box(
+//                            modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .padding(horizontal = 15.dp, vertical = 5.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = option,
+                                    fontFamily = PaperlogyFamily,
+                                    fontWeight = FontWeight.Normal,
+                                    fontSize = 14.sp,
+                                    color = Color.Black,
+                                    textAlign = TextAlign.Center,
+                                    maxLines = 1
+                                )
+                            }
                         }
                     }
                 }
-            }}
+            }
             Spacer(modifier = Modifier.weight(1f))
             Box(
                 modifier = Modifier
@@ -638,7 +646,7 @@ fun ProfileStepThree(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(48.dp)
-                )  {
+                ) {
                     Text(
                         "확인",
                         fontFamily = PaperlogyFamily,

--- a/frontend/app/src/main/java/com/stellan/challang/ui/screen/home/CuratingScreen.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/screen/home/CuratingScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -62,19 +63,25 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.stellan.challang.R
+import com.stellan.challang.data.api.ApiClient
+import com.stellan.challang.data.model.drink.Drink
+import com.stellan.challang.data.repository.DrinkRepository
 import com.stellan.challang.hasSeenGuideFlow
 import com.stellan.challang.rememberRecentSearches
 import com.stellan.challang.saveSearchQuery
 import com.stellan.challang.setGuideShown
 import com.stellan.challang.ui.theme.PaperlogyFamily
+import com.stellan.challang.ui.util.formatAbv
+import com.stellan.challang.ui.viewmodel.DrinkViewModel
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 @SuppressLint("MutableCollectionMutableState")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
+fun CuratingScreen(onDetail: (drink: Drink) -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -86,8 +93,16 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
     val hasSeenGuide by context.hasSeenGuideFlow().collectAsState(initial = false)
     val showGuide = !hasSeenGuide
 
+    val drinkViewModel = remember { DrinkViewModel(DrinkRepository(ApiClient.drinkApi)) }
+    val drinks by drinkViewModel.drinks.collectAsState()
+
+    LaunchedEffect(Unit) {
+        drinkViewModel.fetchDrinks()
+    }
+
+
     Box(Modifier.fillMaxSize()) {
-        Column (Modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
             SearchBar(
                 modifier = Modifier.align(Alignment.CenterHorizontally),
                 inputField = {
@@ -96,11 +111,16 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                         onQueryChange = { text = it },
                         onSearch = {
                             scope.launch { saveSearchQuery(context, text) }
-                            expanded = false },
+                            expanded = false
+                        },
                         expanded = expanded,
                         onExpandedChange = { expanded = it },
-                        trailingIcon = { Icon(Icons.Default.Search,
-                            contentDescription = null) },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription = null
+                            )
+                        },
                     )
                 },
                 expanded = expanded,
@@ -110,10 +130,13 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                 ),
                 shape = RoundedCornerShape(12.dp),
             ) {
-                Column(modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(25.dp)) {
-                    Text("최근 검색어",
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(25.dp)
+                ) {
+                    Text(
+                        "최근 검색어",
                         fontFamily = PaperlogyFamily,
                         fontWeight = FontWeight.SemiBold,
                     )
@@ -127,13 +150,15 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                                     text = past
                                     expanded = false
                                 },
-                                label = { Text(
-                                    text = past,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 5.dp),
-                                    textAlign = TextAlign.Center
-                                ) },
+                                label = {
+                                    Text(
+                                        text = past,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 5.dp),
+                                        textAlign = TextAlign.Center
+                                    )
+                                },
                                 border = SuggestionChipDefaults.suggestionChipBorder(
                                     enabled = true,
                                     borderColor = Color.Transparent
@@ -145,7 +170,8 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                         }
                     }
                     Spacer(modifier = Modifier.height(40.dp))
-                    Text("추천 키워드",
+                    Text(
+                        "추천 키워드",
                         fontFamily = PaperlogyFamily,
                         fontWeight = FontWeight.SemiBold,
                     )
@@ -156,13 +182,15 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                         items(6) { iter ->
                             SuggestionChip(
                                 onClick = {},
-                                label = { Text(
-                                    "사랑해",
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 5.dp),
-                                    textAlign = TextAlign.Center
-                                ) },
+                                label = {
+                                    Text(
+                                        "사랑해",
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 5.dp),
+                                        textAlign = TextAlign.Center
+                                    )
+                                },
                                 border = SuggestionChipDefaults.suggestionChipBorder(
                                     enabled = true,
                                     borderColor = Color.Transparent
@@ -174,7 +202,8 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                         }
                     }
                     Spacer(modifier = Modifier.height(40.dp))
-                    Text("실시간 인기 주류 순위",
+                    Text(
+                        "실시간 인기 주류 순위",
                         fontFamily = PaperlogyFamily,
                         fontWeight = FontWeight.SemiBold,
                     )
@@ -186,13 +215,15 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                         items(8) { iter ->
                             SuggestionChip(
                                 onClick = {},
-                                label = { Text(
-                                    "사랑해",
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 5.dp),
-                                    textAlign = TextAlign.Center
-                                ) },
+                                label = {
+                                    Text(
+                                        "사랑해",
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 5.dp),
+                                        textAlign = TextAlign.Center
+                                    )
+                                },
                                 border = SuggestionChipDefaults.suggestionChipBorder(
                                     enabled = true,
                                     borderColor = Color.Transparent
@@ -206,13 +237,11 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                 }
             }
 
-            val dummy = listOf("발베니", "발렌타인 30년", "짐빔", "조니워커 블루", "로얄샬루트 23년")
-
             var currentIndex by remember { mutableIntStateOf(0) }
             var history by remember { mutableStateOf(listOf<Int>()) }
 
             Box(Modifier.fillMaxSize()) {
-                dummy.forEachIndexed { idx, item ->
+                drinks.forEachIndexed { idx, drink ->
                     if (idx < currentIndex || idx > currentIndex + 1) return@forEachIndexed
 
                     val offsetX = remember { Animatable(0f) }
@@ -222,8 +251,12 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                         Modifier
                             .fillMaxSize()
                             .padding(27.dp)
-                            .offset { IntOffset(offsetX.value.roundToInt(),
-                                offsetY.value.roundToInt()) }
+//                            .offset {
+//                                IntOffset(
+//                                    offsetX.value.roundToInt(),
+//                                    offsetY.value.roundToInt()
+//                                )
+//                            }
                             .pointerInput(currentIndex) {
                                 detectDragGestures(
                                     onDragEnd = {
@@ -232,12 +265,13 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                                             offsetY.value > threshold -> {
                                                 history = history + currentIndex
                                                 currentIndex = (currentIndex + 1)
-                                                    .coerceAtMost(dummy.lastIndex)
+                                                    .coerceAtMost(drinks.lastIndex)
                                                 scope.launch {
                                                     offsetX.snapTo(0f)
                                                     offsetY.snapTo(0f)
                                                 }
                                             }
+
                                             offsetY.value < -threshold -> {
                                                 if (history.isNotEmpty()) {
                                                     currentIndex = history.last()
@@ -248,24 +282,27 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                                                     offsetY.snapTo(0f)
                                                 }
                                             }
-                                            offsetX.value > threshold -> {
-                                                history = history + currentIndex
-                                                currentIndex = (currentIndex + 1)
-                                                    .coerceAtMost(dummy.lastIndex)
-                                                scope.launch {
-                                                    offsetX.snapTo(0f)
-                                                    offsetY.snapTo(0f)
-                                                }
-                                            }
-                                            offsetX.value < -threshold -> {
-                                                history = history + currentIndex
-                                                currentIndex = (currentIndex + 1)
-                                                    .coerceAtMost(dummy.lastIndex)
-                                                scope.launch {
-                                                    offsetX.snapTo(0f)
-                                                    offsetY.snapTo(0f)
-                                                }
-                                            }
+
+//                                            offsetX.value > threshold -> {
+//                                                history = history + currentIndex
+//                                                currentIndex = (currentIndex + 1)
+//                                                    .coerceAtMost(drinks.lastIndex)
+//                                                scope.launch {
+//                                                    offsetX.snapTo(0f)
+//                                                    offsetY.snapTo(0f)
+//                                                }
+//                                            }
+//
+//                                            offsetX.value < -threshold -> {
+//                                                history = history + currentIndex
+//                                                currentIndex = (currentIndex + 1)
+//                                                    .coerceAtMost(drinks.lastIndex)
+//                                                scope.launch {
+//                                                    offsetX.snapTo(0f)
+//                                                    offsetY.snapTo(0f)
+//                                                }
+//                                            }
+
                                             else -> {
                                                 scope.launch {
                                                     offsetX.animateTo(0f, tween(300))
@@ -297,11 +334,14 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                         colors = CardDefaults.cardColors(containerColor = Color.Transparent)
                     ) {
                         Box(Modifier.fillMaxSize()) {
-                            Image(
-                                painter = painterResource(R.drawable.ballantines_30_years_old),
+                            AsyncImage(
+                                model = drink.imageUrl,
                                 contentDescription = null,
-                                contentScale = ContentScale.FillWidth,
-                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(450.dp)
+                                    .offset(y = 80.dp),
                                 alignment = Alignment.Center
                             )
 
@@ -311,21 +351,25 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                                     .padding(top = 42.dp, start = 24.dp)
                             ) {
                                 Text(
-                                    text = dummy[currentIndex],
+                                    text = drink.name,
                                     fontFamily = PaperlogyFamily,
                                     fontWeight = FontWeight.Bold,
                                     fontSize = 34.sp,
                                     color = Color.White
                                 )
                                 Text(
-                                    text = "40%",
+                                    text = if (drink.minAbv == drink.maxAbv) {
+                                        "${formatAbv(drink.minAbv)}%"
+                                    } else {
+                                        "${formatAbv(drink.minAbv)}~${formatAbv(drink.maxAbv)}%"
+                                    },
                                     fontFamily = PaperlogyFamily,
                                     fontWeight = FontWeight.Bold,
                                     fontSize = 34.sp,
                                     color = Color.White
                                 )
                                 Text(
-                                    text = "고도수",
+                                    text = drink.typeName,
                                     fontFamily = PaperlogyFamily,
                                     fontWeight = FontWeight.Bold,
                                     fontSize = 34.sp,
@@ -346,7 +390,7 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                                     contentAlignment = Alignment.Center
                                 ) {
                                     TextButton(
-                                        onClick = { onDetail("1") },
+                                        onClick = { onDetail(drink) },
                                         colors = ButtonDefaults.buttonColors(
                                             containerColor = Color(0xFF98DFE5)
                                         ),
@@ -366,18 +410,22 @@ fun CuratingScreen(onDetail: (drinkID: String) -> Unit) {
                                     horizontalArrangement = Arrangement.Center
                                 ) {
                                     IconButton(onClick = { /* 공유 */ }) {
-                                        Icon(Icons.Outlined.Share,
+                                        Icon(
+                                            Icons.Outlined.Share,
                                             contentDescription = "공유하기",
                                             tint = Color(0xFF6CD0D8),
                                             modifier = Modifier
-                                                .size(35.dp))
+                                                .size(35.dp)
+                                        )
                                     }
                                     IconButton(onClick = { /* 다운로드 */ }) {
-                                        Icon(Icons.Default.Download,
+                                        Icon(
+                                            Icons.Default.Download,
                                             contentDescription = "다운로드",
                                             tint = Color(0xFF6CD0D8),
                                             modifier = Modifier
-                                                .size(35.dp))
+                                                .size(35.dp)
+                                        )
                                     }
                                 }
                             }

--- a/frontend/app/src/main/java/com/stellan/challang/ui/screen/home/DrinkDetailScreen.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/screen/home/DrinkDetailScreen.kt
@@ -50,14 +50,17 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.stellan.challang.R
+import com.stellan.challang.data.model.drink.Drink
 import com.stellan.challang.ui.component.StarRatingDecimal
 import com.stellan.challang.ui.theme.PaperlogyFamily
+import com.stellan.challang.ui.util.formatAbv
 import kotlin.math.roundToInt
 
 @Composable
 fun DrinkDetailScreen(
-    drinkId: String,
+    drink: Drink,
     onViewReviews: () -> Unit
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
@@ -73,11 +76,14 @@ fun DrinkDetailScreen(
                         shape = RoundedCornerShape(24.dp)
                     )
             ) {
-                Image(
-                    painter = painterResource(R.drawable.balvenie),
+                AsyncImage(
+                    model = drink.imageUrl,
                     contentDescription = null,
-                    contentScale = ContentScale.FillWidth,
-                    modifier = Modifier.fillMaxWidth().padding(top = 50.dp, bottom = 70.dp)
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(600.dp)
+                        .padding(top = 50.dp, bottom = 70.dp)
                 )
             }
         }
@@ -90,14 +96,18 @@ fun DrinkDetailScreen(
                 verticalAlignment = Alignment.Bottom
             ) {
                 Text(
-                    "발베니",
+                    drink.name,
                     fontFamily = PaperlogyFamily,
                     fontWeight = FontWeight.SemiBold,
                     fontSize = 26.sp
                 )
                 Spacer(Modifier.width(12.dp))
                 Text(
-                    "위스키 40도",
+                    if (drink.minAbv == drink.maxAbv) {
+                        "${drink.typeName} ${formatAbv(drink.minAbv)}도"
+                    } else {
+                        "${drink.typeName} ${formatAbv(drink.minAbv)}~${formatAbv(drink.maxAbv)}도"
+                    },
                     fontFamily = PaperlogyFamily,
                     fontWeight = FontWeight.Normal,
                     fontSize = 16.sp,
@@ -117,18 +127,22 @@ fun DrinkDetailScreen(
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalArrangement = Arrangement.spacedBy((-3).dp),
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 30.dp)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 30.dp)
             ) {
-                repeat(11) {
+                drink.liquorTags.forEach { tag ->
                     FilterChip(
                         selected = false,
                         onClick = { },
-                        label = { Text(
-                            "바닐라향",
-                            fontSize = 13.sp,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.fillMaxWidth()
-                        ) },
+                        label = {
+                            Text(
+                                tag.tagName,
+                                fontSize = 13.sp,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        },
                         border = BorderStroke(0.dp, Color.Transparent),
                         colors = FilterChipDefaults.filterChipColors(
                             containerColor = Color(0xFFCEEFF2)
@@ -149,10 +163,7 @@ fun DrinkDetailScreen(
                     .background(Color(0xFFCEEFF2), shape = RoundedCornerShape(10.dp))
             ) {
                 Text(
-                    "짐빔(Jim Beam)은 미국 켄터키주에서 생산되는 대표적인 버번 위스키에요." +
-                        "1795년부터 이어져 온 전통과 독자적인 제조법으로 깊고 부드러운 풍미를 자랑하죠." +
-                        "오크통에서 숙성된 특유의 풍미가 세계적으로 사랑받고 있으며," +
-                        "다양한 칵테일 베이스로도 널리 활용된답니다.",
+                    drink.origin,
                     fontWeight = FontWeight.Normal,
                     fontSize = 13.sp,
                     lineHeight = 30.sp,
@@ -174,11 +185,7 @@ fun DrinkDetailScreen(
                     modifier = Modifier.padding(start = 15.dp, top = 15.dp)
                 )
                 Text(
-                    "짐빔은 은은한 바닐라와 캐러멜 향을 중심으로, 고소한 옥수수 곡물 향과 오크 나무 숙성에서 비롯된" +
-                            " 부드럽고 깊이 있는 풍미가 느껴지는 버번 위스키입니다." +
-                        "적당한 단맛과 함께 살짝 스파이시한 느낌이 균형을 이루어, 전반적으로 깔끔하고 산뜻한 인상을 줍니다." +
-                        "맛이 무겁거나 강하지 않아 초심자들도 부담 없이 즐기기 좋으며," +
-                        "스트레이트, 온더록, 하이볼, 칵테일 등 다양한 방식으로 활용할 수 있는 활용도 높은 위스키입니다.",
+                    drink.tastingNote,
                     fontWeight = FontWeight.Normal,
                     fontSize = 12.sp,
                     lineHeight = 24.sp,
@@ -190,7 +197,7 @@ fun DrinkDetailScreen(
         }
 
         item {
-            val degree = 40f
+            val degree = drink.maxAbv.toFloat()
             val valueRange = 0f..60f
 
             var sliderWidthPx by remember { mutableIntStateOf(0) }
@@ -226,15 +233,21 @@ fun DrinkDetailScreen(
                 val xOffsetPx = horizontalPaddingPx + (trackWidthPx - thumbRadiusPx * 2) * fraction
 
                 Text(
-                    "40도",
+                    "${formatAbv(drink.maxAbv)}도",
                     fontWeight = FontWeight.Normal,
                     modifier = Modifier
-                        .offset { IntOffset(xOffsetPx.roundToInt(),
-                            50.dp.toPx().roundToInt()) }
+                        .offset {
+                            IntOffset(
+                                xOffsetPx.roundToInt(),
+                                50.dp.toPx().roundToInt()
+                            )
+                        }
                 )
             }
-            HorizontalDivider(Modifier.padding(30.dp),
-                thickness = 3.dp, color = Color(0xFFCEEFF2))
+            HorizontalDivider(
+                Modifier.padding(30.dp),
+                thickness = 3.dp, color = Color(0xFFCEEFF2)
+            )
         }
 
         item {
@@ -258,7 +271,7 @@ fun DrinkDetailScreen(
                         fontWeight = FontWeight.Normal,
                         fontSize = 12.sp,
                         color = Color(0xFF6D6B6B),
-                        modifier = Modifier.clickable{ onViewReviews() }
+                        modifier = Modifier.clickable { onViewReviews() }
                     )
                 }
                 Spacer(Modifier.height(10.dp))
@@ -299,14 +312,16 @@ fun DrinkDetailScreen(
                             repeat(3) {
                                 SuggestionChip(
                                     onClick = {},
-                                    label = { Text(
-                                        "바닐라향",
-                                        fontSize = 8.sp,
-                                        color = Color.Black,
-                                        textAlign = TextAlign.Center,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    ) },
+                                    label = {
+                                        Text(
+                                            "바닐라향",
+                                            fontSize = 8.sp,
+                                            color = Color.Black,
+                                            textAlign = TextAlign.Center,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    },
                                     border = BorderStroke(0.dp, Color.Transparent),
                                     colors = SuggestionChipDefaults.suggestionChipColors(
                                         containerColor = Color.White
@@ -361,7 +376,7 @@ fun DrinkDetailScreen(
                                 contentScale = ContentScale.FillHeight
                             )
                         }
-                        Column(Modifier.padding(top = 15.dp, bottom = 15.dp,)) {
+                        Column(Modifier.padding(top = 15.dp, bottom = 15.dp)) {
                             Text(
                                 "발렌타인 30년",
                                 fontSize = 18.sp
@@ -376,14 +391,16 @@ fun DrinkDetailScreen(
                                 repeat(6) {
                                     SuggestionChip(
                                         onClick = {},
-                                        label = { Text(
-                                            "바닐라향",
-                                            fontSize = 9.sp,
-                                            color = Color.Black,
-                                            textAlign = TextAlign.Center,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                        ) },
+                                        label = {
+                                            Text(
+                                                "바닐라향",
+                                                fontSize = 9.sp,
+                                                color = Color.Black,
+                                                textAlign = TextAlign.Center,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                        },
                                         border = BorderStroke(0.dp, Color.Transparent),
                                         colors = SuggestionChipDefaults.suggestionChipColors(
                                             containerColor = Color(0xFFCEEFF2)

--- a/frontend/app/src/main/java/com/stellan/challang/ui/screen/home/MainScreen.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/screen/home/MainScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -31,12 +32,16 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.stellan.challang.data.api.ApiClient
+import com.stellan.challang.data.repository.DrinkRepository
 import com.stellan.challang.ui.navigation.mainNavGraph
 import com.stellan.challang.ui.theme.PaperlogyFamily
+import com.stellan.challang.ui.viewmodel.DrinkViewModel
 
 @Composable
 fun MainScreen(rootNavController: NavHostController) {
     val bottomNavController = rememberNavController()
+    val drinkViewModel = remember { DrinkViewModel(DrinkRepository(ApiClient.drinkApi)) }
 
     Scaffold(
         bottomBar = { BottomBar(bottomNavController) }
@@ -57,7 +62,7 @@ fun MainScreen(rootNavController: NavHostController) {
                     navController  = bottomNavController,
                     startDestination = "home"
                 ) {
-                    mainNavGraph(rootNavController, bottomNavController)
+                    mainNavGraph(rootNavController, bottomNavController, drinkViewModel)
                 }
             }
             HorizontalDivider(

--- a/frontend/app/src/main/java/com/stellan/challang/ui/util/formatAbv.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/util/formatAbv.kt
@@ -1,0 +1,9 @@
+package com.stellan.challang.ui.util
+
+fun formatAbv(value: Double): String {
+    return if (value % 1.0 == 0.0) {
+        value.toInt().toString()
+    } else {
+        value.toString()
+    }
+}

--- a/frontend/app/src/main/java/com/stellan/challang/ui/viewmodel/DrinkViewModel.kt
+++ b/frontend/app/src/main/java/com/stellan/challang/ui/viewmodel/DrinkViewModel.kt
@@ -1,0 +1,44 @@
+package com.stellan.challang.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stellan.challang.data.model.auth.TokenProvider
+import com.stellan.challang.data.model.drink.Drink
+import com.stellan.challang.data.model.drink.DrinkResponse
+import com.stellan.challang.data.repository.DrinkRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class DrinkViewModel(
+    private val repository: DrinkRepository
+) : ViewModel() {
+
+    private val _drinks = MutableStateFlow<List<Drink>>(emptyList())
+    val drinks: StateFlow<List<Drink>> = _drinks.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _selectedDrink = MutableStateFlow<Drink?>(null)
+    val selectedDrink: StateFlow<Drink?> = _selectedDrink.asStateFlow()
+
+    fun selectDrink(drink: Drink) {
+        _selectedDrink.value = drink
+    }
+
+
+    fun fetchDrinks() {
+        viewModelScope.launch {
+            try {
+                val refreshToken = TokenProvider.getRefreshToken() ?: return@launch
+                val response = repository.getRecommendedDrinks("Bearer $refreshToken")
+                _drinks.value = response;
+            } catch (e: Exception) {
+                println("술 실패 ${e}")
+                _error.value = "주류 불러오기 실패: ${e.message}"
+            }
+        }
+    }
+}

--- a/frontend/gradle/libs.versions.toml
+++ b/frontend/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.11.1"
+coilCompose = "2.7.0"
 converterGson = "3.0.0"
 datastorePreferences = "1.1.7"
 glide = "4.16.0"
@@ -28,6 +29,7 @@ androidx-foundation = { module = "androidx.compose.foundation:foundation", versi
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
- DrinkApiService에 추천 주류 API (`getRecommendedDrinks`) 추가
- DrinkRepository 생성 및 응답 예외 처리 포함
- DrinkViewModel 구현: StateFlow로 drinks / error 상태 관리
- CuratingScreen에서 ViewModel 연동 및 카드 UI에 API 데이터 바인딩
- 기존 dummy 리스트 제거하고 실제 서버 응답 기반으로 렌더링